### PR TITLE
fix library export, add default library destination to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /src/*
 !/src/audible_cli
 /src/audible_cli/*.bak
+library.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/audible_cli/cmds/cmd_library.py
+++ b/src/audible_cli/cmds/cmd_library.py
@@ -15,8 +15,8 @@ def cli():
 
 
 async def _export_library(auth, **params):
-    with audible.Client(auth) as client:
-        library = Library.get_from_api(
+    async with audible.AsyncClient(auth) as client:
+        library = await Library.aget_from_api(
             client,
             response_groups=(
                 "contributors, media, price, product_attrs, product_desc, "
@@ -40,7 +40,7 @@ async def _export_library(auth, **params):
     ]
 
     writer = csv.DictWriter(
-        f.open("w"), fieldnames=headers, dialect="excel-tab"
+        f.open("w", encoding="utf-8"), fieldnames=headers, dialect="excel-tab"
     )
     writer.writeheader()
 

--- a/src/audible_cli/cmds/cmd_library.py
+++ b/src/audible_cli/cmds/cmd_library.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 import pathlib
 
+import audible
 import click
 
 from ..config import pass_session
@@ -14,19 +15,20 @@ def cli():
 
 
 async def _export_library(auth, **params):
-    library = await Library.get_from_api(
-        auth,
-        response_groups=(
-            "contributors, media, price, product_attrs, product_desc, "
-            "product_extended_attrs, product_plan_details, product_plans, "
-            "rating, sample, sku, series, reviews, ws4v, origin, "
-            "relationships, review_attrs, categories, badge_types, "
-            "category_ladders, claim_code_url, is_downloaded, is_finished, "
-            "is_returnable, origin_asin, pdf_url, percent_complete, "
-            "provided_review"
-        ),
-        num_results=1000
-    )
+    with audible.Client(auth) as client:
+        library = Library.get_from_api(
+            client,
+            response_groups=(
+                "contributors, media, price, product_attrs, product_desc, "
+                "product_extended_attrs, product_plan_details, product_plans, "
+                "rating, sample, sku, series, reviews, ws4v, origin, "
+                "relationships, review_attrs, categories, badge_types, "
+                "category_ladders, claim_code_url, is_downloaded, is_finished, "
+                "is_returnable, origin_asin, pdf_url, percent_complete, "
+                "provided_review"
+            ),
+            num_results=1000
+        )
 
     f = pathlib.Path(params.get("output"))
 
@@ -92,7 +94,7 @@ def export_library(session, **params):
     """export library"""
     loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(_export_library(session.config.auth, **params))
+        loop.run_until_complete(_export_library(session.auth, **params))
     finally:
         loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -33,6 +33,9 @@ class LibraryItem:
         self._locale = locale or auth.locale
         self._auth = auth
 
+    def __iter__(self):
+        return iter(self._data)
+
     def __getitem__(self, key):
         return self._data[key]
 
@@ -100,7 +103,7 @@ class LibraryItem:
                   f"Skip asin {self.asin}.")
 
     def _get_codec(self, quality: str):
-        """If quality is not ``best``, ensures the given quality is present in 
+        """If quality is not ``best``, ensures the given quality is present in
         them codecs list. Otherwise, will find the best aax quality available
         """
         assert quality in ("best", "high", "normal",)


### PR DESCRIPTION
When trying to run the library export cmd, I encountered an error that did not seem to be related to my configuration.  I dove into the code and found that the library export functionality seemed to be out of date with the classes in the models file, so I updated the library export cmd to work.  I did my best to retain the existing logic and conventions.