### PR TITLE
Provide a command to list library titles

### DIFF
--- a/src/audible_cli/_version.py
+++ b/src/audible_cli/_version.py
@@ -1,7 +1,7 @@
 __title__ = "audible-cli"
 __description__ = "Command line interface (cli) for the audible package."
 __url__ = "https://github.com/mkb79/audible-cli"
-__version__ = "0.0.dev14"
+__version__ = "0.0.dev15"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible_cli/cmds/cmd_library.py
+++ b/src/audible_cli/cmds/cmd_library.py
@@ -41,8 +41,8 @@ async def _list_library(auth, **params):
     books = []
 
     for item in library:
-        authors = ', '.join(sorted(a['name'] for a in item.authors) if item.authors else '')
-        series = ', '.join(sorted(s['title'] for s in item.series) if item.series else '')
+        authors = ", ".join(sorted(a["name"] for a in item.authors) if item.authors else "")
+        series = ", ".join(sorted(s["title"] for s in item.series) if item.series else "")
         title = item.title
         books.append((authors, series, title))
 
@@ -54,7 +54,6 @@ async def _list_library(auth, **params):
             fields.append(series)
         fields.append(title)
         echo(": ".join(fields))
-
 
 
 async def _export_library(auth, **params):


### PR DESCRIPTION
..just about what the name says.  It lists them sorted in the following format:

[comma-separated alpha authors: ][comma-separated alpha series: ]<title>

..where items in [] show up opportunistically and are used to sort, and the title is always present.

So, for some examples:
```
$> audible library list
A mysterious book without authors or series
Anonymous Adventures: Volume 1 - The Sky is the Limit
Anonymous Adventures: Volume 2 - The Dark Sea
Bob Noscovesk, Tim Mu: Fantastic Animals, The Best Animals Collection: How I met my cat and fell in love
Bob Noscovesk, Tim Mu: Fantastic Animals, The Best Animals Collection: Reddit Copypasta (hardcopy)
Tim Mu:  How I became tired of meaningless happiness derived from cute things
Viability - How Not to Become Obsolete as the World Rolls Blindly Forward
```

This will usually show up as intended.  However, in the case of *some* books having multiple series/authors and *others* not having that, the sorting might be weird in some cases:

```
Author A, Author C: Moxy Mysteries: A cat without a name
Author B: A great Standalone Piece of Fiction by Me!
Author C: Moxy Mysteries: The dog with no dog breath
```

The vast majority of books have a single author, though, or at least a consistent set of authors, and outliers still get listed, they just might not show up where someone would expect.