### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ runs on the interactive mode, so you have to answer multiple questions to finish
 ## Commands
 
 Call `audible -h` to let you show all main subcommands. At this time, there 
-are the `activation_bytes`, `download`, `library` and `manage` subcommands. 
+are the `activation-bytes`, `download`, `library` and `manage` subcommands. 
 The `manage` command has multiple subcommands. So take a look with the 
 `audible manage -h` and `audible manage <subcommand> -h`. 
 


### PR DESCRIPTION
Underline activation_bytes is incorrect.

Call `audible -h` to let you show all main subcommands. At this time, there 
are the `activation_bytes`, `download`, `library` and `manage` subcommands. 
The `manage` command has multiple subcommands. So take a look with the 
`audible manage -h` and `audible manage <subcommand> -h`.

```
$ audible -h
Usage: audible [OPTIONS] COMMAND [ARGS]...

  Entrypoint for all other subcommands and groups.

Options:
  -P, --profile TEXT   The profile to use instead primary profile (case
                       sensitive!).
  -p, --password TEXT  The password for the profile auth file.
  --version            Show the version and exit.
  -h, --help           Show this message and exit.

Commands:
  activation-bytes  Get activation bytes.
  download          download audiobook(s) from library
  library           interact with library
  manage            manage audible-cli
  quickstart        Quicksetup audible
```