### PR TITLE
Print out the image urls for different resolutions for a book not in your library

### DIFF
--- a/plugin_cmds/cmd_image-urls.py
+++ b/plugin_cmds/cmd_image-urls.py
@@ -13,10 +13,10 @@ from audible_cli.config import pass_session
 def cli(session, asin):
     "Print out the image urls for different resolutions for a book"
     with audible.Client(auth=session.auth) as client:
-        r = client.get(f"library/{asin}",
+        r = client.get(f"catalog/products/{asin}",
                        response_groups="media",
                        image_sizes=("1215, 408, 360, 882, 315, 570, 252, "
                                     "558, 900, 500"))
-    images = r["item"]["product_images"]
+    images = r["product"]["product_images"]
     for res, url in images.items():
         click.echo(f"Resolution {res}: {url}")


### PR DESCRIPTION
#### What is the relevant ticket?
* This change allows to also download covers of audio books that are not in your library

#### What’s this PR do?
##### Change
* API path to `v1/catalog/products/{asin}`

#### Where should the reviewer start?
* `plugin_cmds/cmd_image-urls.py`

#### How should this be manually tested?
* Try to fetch ASIN that is not in your library. For example `AUDIBLE_PLUGIN_DIR=plugin_cmds/ audible get-cover-urls -a B08WRJHRJ3`

#### Risk involved?
* No

#### Screenshots (if appropriate):
* N/A

#### Does the documentation or dependencies need an update?
* Maybe?
