### PR TITLE
Using config file for filename_mode preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ provide the password.
 If the auth file is encrypted, and you don’t provide the password, you will be 
 asked for it with a „hidden“ input field. 
 
+### Config options
+
+An option in the config file is separated by an underline. In the CLI prompt,
+an option must be entered with a dash.
+
+#### APP section
+
+The APP section supports the following options:
+- primary_profile: The profile to use, if no other is specified
+- filename_mode: When using the `download` command, a filename mode can be 
+  specified here. If not present, "ascii" will be used as default. To override
+  these option, you can provide a mode with the `filename-mode` option of the
+  download command.
+
+#### Profile section
+
+- auth_file: The auth file for this profile
+- country_code: The marketplace for this profile
+- filename_mode: See APP section above. Will override the option in APP section.
+
 ## Getting started
 
 Use the `audible-quickstart` or `audible quickstart` command in your shell 

--- a/src/audible_cli/_version.py
+++ b/src/audible_cli/_version.py
@@ -1,7 +1,7 @@
 __title__ = "audible-cli"
 __description__ = "Command line interface (cli) for the audible package."
 __url__ = "https://github.com/mkb79/audible-cli"
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -204,7 +204,7 @@ async def main(config, auth, **params):
     no_confirm = params.get("no_confirm")
 
     filename_mode = params.get("filename_mode")
-    if filename_mode == "auto":
+    if filename_mode == "config":
         filename_mode = config.profile_config.get("filename_mode") or \
                         config.app_config.get("filename_mode") or \
                         "ascii"
@@ -410,10 +410,10 @@ async def main(config, auth, **params):
 @click.option(
     "--filename-mode", "-f",
     type=click.Choice(
-        ["auto", "ascii", "asin_ascii", "unicode", "asin_unicode"]
+        ["config", "ascii", "asin_ascii", "unicode", "asin_unicode"]
     ),
-    default="auto",
-    help="Filename mode to use. [default: auto]"
+    default="config",
+    help="Filename mode to use. [default: config]"
 )
 @pass_session
 def cli(session, **params):

--- a/src/audible_cli/config.py
+++ b/src/audible_cli/config.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import click
 import toml
@@ -23,6 +23,7 @@ class Config:
     def __init__(self) -> None:
         self._config_file: Optional[pathlib.Path] = None
         self._config_data: Dict[str, Union[str, Dict]] = DEFAULT_CONFIG_DATA
+        self._current_profile: Optional[str] = None
         self._is_read: bool = False
 
     @property
@@ -48,14 +49,19 @@ class Config:
         return self._config_data
 
     @property
+    def app_config(self) -> Dict[str, str]:
+        return self.data.get("APP", {})
+
+    @property
+    def profile_config(self) -> Dict[str, str]:
+        return self.data["profile"][self._current_profile]
+
+    @property
     def primary_profile(self) -> Optional[str]:
-        return self.data.get("APP", {}).get("primary_profile")
+        return self.app_config.get("primary_profile")
 
     def has_profile(self, name: str) -> bool:
         return name in self.data.get("profile", {})
-
-    def get_profile(self, name: str) -> Dict[str, str]:
-        return self.data["profile"][name]
 
     def add_profile(self,
                     name: str,
@@ -142,28 +148,31 @@ class Session:
             conf_file = self.app_dir / CONFIG_FILE
             self._config = Config()
             self._config.read_config(conf_file)
+
+            name = self.params.get("profile") or self.config.primary_profile
+            if name is None:
+                message = ("No profile provided and primary profile not set "
+                           "properly in config.")
+                try:
+                    ctx = click.get_current_context()
+                    ctx.fail(message)
+                except RuntimeError:
+                    raise KeyError(message)
+
+            if not self.config.has_profile(name):
+                message = "Provided profile not found in config."
+                try:
+                    ctx = click.get_current_context()
+                    ctx.fail(message)
+                except RuntimeError:
+                    raise UserWarning(message)
+
+            self.config._current_profile = name
+
         return self._config
 
     def _set_auth(self):
-        name = self.params.get("profile") or self.config.primary_profile
-        if name is None:
-            message = ("No profile provided and primary profile not set "
-                       "properly in config.")
-            try:
-                ctx = click.get_current_context()
-                ctx.fail(message)
-            except RuntimeError:
-                raise KeyError(message)
-
-        if not self.config.has_profile(name):
-            message = "Provided profile not found in config."
-            try:
-                ctx = click.get_current_context()
-                ctx.fail(message)
-            except RuntimeError:
-                raise UserWarning(message)
-
-        profile = self.config.get_profile(name)
+        profile = self.config.profile_config
         auth_file = self.config.dirname / profile["auth_file"]
         country_code = profile["country_code"]
         password = self.params.get("password")
@@ -211,4 +220,3 @@ def add_param_to_session(ctx: click.Context, param, value):
     session = ctx.ensure_object(Session)
     session.params[param.name] = value
     return value
-

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -58,7 +58,14 @@ class LibraryItem:
         cleaned_title = unicodedata.normalize("NFKD", self.full_title)
         cleaned_title = cleaned_title.encode("ASCII", "ignore")
         cleaned_title = cleaned_title.replace(b" ", b"_")
-        return "".join(chr(c) for c in cleaned_title if chr(c) in valid_chars)
+        slug_title = "".join(
+            chr(c) for c in cleaned_title if chr(c) in valid_chars
+        )
+
+        if len(slug_title) < 2:
+            return self.asin
+
+        return slug_title
 
     def substring_in_title_accuracy(self, substring):
         match = LongestSubString(substring, self.full_title)


### PR DESCRIPTION
When downloading a file, `filename_mode`is set to auto by default.

Audible-cli looks for the `filename_mode` setting in this order:

- cli command
- config file > profile section
- config file > app section
- using "ascii" mode if nothing is provided