### PR TITLE
Detect responses which are too small

### DIFF
--- a/src/audible_cli/constants.py
+++ b/src/audible_cli/constants.py
@@ -4,6 +4,7 @@ CONFIG_DIR_ENV: str = "AUDIBLE_CONFIG_DIR"
 PLUGIN_PATH: str = "plugins"
 PLUGIN_DIR_ENV: str = "AUDIBLE_PLUGIN_DIR"
 PLUGIN_ENTRY_POINT: str = "audible.cli_plugins"
+MINIMUM_FILE_SIZE: int = 65536 # if it's not at least 64KB there is no way it's a real file
 DEFAULT_AUTH_FILE_EXTENSION: str = "json"
 DEFAULT_AUTH_FILE_ENCRYPTION: str = "json"
 DEFAULT_CONFIG_DATA = {


### PR DESCRIPTION
Your fix for #48 should help in some cases, but did not help in my case which turned out to be (reasonably) that the books I was trying to download were actually just "included in [my] membership" rather than books I paid for. It's reasonable I suppose that they don't want me to download those ;-) Either way it should detect that and not save it as an AAX file.

I figure that if a "book" isn't at least 64kb in size (8 seconds of 64kbps audio without headers...) then there is no way it's a successful download, so this seems like a reasonable way to fix the issue to me, but I'll let you decide how to do it. I have tested this though and it solves the issue for me.