### PR TITLE
Development

### DIFF
--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -228,22 +228,21 @@ async def download_aax(
         client, output_dir, base_filename, item,
         quality, overwrite_existing, allow_alternate_formats
 ):
-    # url, codec = await item.get_aax_url(quality)
-    url, codec = await item.get_aax_url_old(quality)
-    filename = base_filename + f"-{codec}.aax"
-    filepath = output_dir / filename
-    dl = Downloader(
-        url, filepath, client, overwrite_existing,
-        ["audio/aax", "audio/vnd.audible.aax", "audio/audible"]
-    )
     try:
+        url, codec = await item.get_aax_url_old(quality)
+        filename = base_filename + f"-{codec}.aax"
+        filepath = output_dir / filename
+        dl = Downloader(
+            url, filepath, client, overwrite_existing,
+            ["audio/aax", "audio/vnd.audible.aax", "audio/audible"]
+        )
         downloaded = await dl.run(pb=True)
 
         if downloaded:
             counter.count_aax()
-
     except:
-        logger.error('AAX file requested but not available.')
+        # if the above fails for some reason, try again with all the same
+        # parameters, except aaxc instead of aax
         if allow_alternate_formats:
             return await download_aaxc(
                 client=client,

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -213,14 +213,16 @@ class LibraryItem(BaseItem):
         if self.customer_rights is not None:
             if not self.customer_rights["is_consumable_offline"]:
                 return False
-            else:
-                return True
+            # origin_type is set to Purchase for titles bought with
+            # credits or money, and None for titles 'Included with
+            # Membership'. The latter require downloading as aaxc files
+            if self.origin_type == None:
+                return False
+            return True
 
     async def get_aax_url_old(self, quality: str = "high"):
         if not self.is_downloadable():
-            raise AudibleCliException(
-                f"{self.full_title} is not downloadable. Skip item."
-            )
+            return await self.get_aaxc_url(quality=quality)
 
         codec, codec_name = self._get_codec(quality)
         if codec is None:

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -82,16 +82,16 @@ class BaseItem:
 
         if "ascii" in mode:
             base_filename = self.full_title_slugify
-    
+
         elif "unicode" in mode:
             base_filename = unicodedata.normalize("NFKD", self.full_title)
-    
+
         else:
             base_filename = self.asin
-    
+
         if "asin" in mode:
             base_filename = self.asin + "_" + base_filename
-    
+
         return base_filename
 
     def substring_in_title_accuracy(self, substring):
@@ -169,12 +169,12 @@ class LibraryItem(BaseItem):
 
     async def get_child_items(self, **request_params) -> Optional["Library"]:
         """Get child elements of MultiPartBooks and Podcasts
-        
+
         With these all parts of a MultiPartBook or all episodes of a Podcasts
         can be shown.
         """
 
-        # Only items with content_delivery_type 
+        # Only items with content_delivery_type
         # MultiPartBook or Periodical have child elements
         if not self.has_children:
             return
@@ -227,7 +227,7 @@ class LibraryItem(BaseItem):
             raise AudibleCliException(
                 f"{self.full_title} is not downloadable in AAX format"
             )
-        
+
         url = (
             "https://cde-ta-g7g.amazon.com/FionaCDEServiceEngine/"
             "FSDownloadContent"

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -234,6 +234,10 @@ class Downloader:
                     msg = self._tmp_file.read_text()
                 except:  # noqa
                     msg = "Unknown"
+                if msg == 'No Library Record Found for user.':
+                    logger.error('No Library Record Found for user. Check if available in different format.')
+                    raise Exception
+
                 logger.error(
                     f"Error downloading {self._file}. Wrong content type. "
                     f"Expected type(s): {self._expected_content_type}; "


### PR DESCRIPTION
Added the --allow-alternate-formats flag. Relevant when you try to download the AAX format of a book, but it's not available for whatever reason. In my case, it seems that any book not owned by you, but just 'Included in Membership', can't be downloaded as AAX. In those cases, an exception is thrown and we try to download AAXC instead, leaving all other parameters the same.