### PR TITLE
Allow book tiltes with hyphens

### DIFF
--- a/plugin_cmds/cmd_remove-encryption.py
+++ b/plugin_cmds/cmd_remove-encryption.py
@@ -184,7 +184,7 @@ def decrypt_aax(files, activation_bytes, rebuild_chapters):
         outfile = file.with_suffix(".m4b")
         metafile = file.with_suffix(".meta")
         metafile_new = file.with_suffix(".new.meta")
-        base_filename = file.stem.rsplit("-")[0]
+        base_filename = file.stem.rsplit("-", 1)[0]
         chapters = file.with_name(base_filename + "-chapters").with_suffix(".json")
         apimeta = json.loads(chapters.read_text())
 


### PR DESCRIPTION
Currently we take the first value before the hyphen, unfortunately books
sometimes have hyphens in the titles meaning that the command will fail.
A simple fix for this is to limit the number of splits that we do once
we have found the end delimiter.
