### PR TITLE
Currently paths with dots will break the decrypt this correct that

### DIFF
--- a/plugin_cmds/cmd_remove-encryption.py
+++ b/plugin_cmds/cmd_remove-encryption.py
@@ -185,7 +185,7 @@ def decrypt_aax(files, activation_bytes, rebuild_chapters):
         metafile = file.with_suffix(".meta")
         metafile_new = file.with_suffix(".new.meta")
         base_filename = file.stem.rsplit("-")[0]
-        chapters = file.with_name(base_filename + "-chapters").with_suffix(".json")
+        chapters = file.with_name(base_filename + "-chapters.json")
         apimeta = json.loads(chapters.read_text())
 
         if outfile.exists():


### PR DESCRIPTION
This problem is caused by "with_suffix" replacing the suffix and not
just adding a new suffix on the end. We can fix this by adding the
"json" to the with_name, so it doesn't remove everything after the first
".".
