### PR TITLE
New CLI flag: after

### DIFF
--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -469,7 +469,8 @@ def display_counter():
     "--after",
     type=str,
     default='1970-01-01T00:10:09.000Z',
-    help="timestamp for 'purchased after' date. In bash:\n'date +%s000'"
+    help="timestamp for 'purchased after' date. In bash:"
+         "date '+%Y-%m-%dT%H:%Mz'"
 )
 @click.option(
     "--asin", "-a",

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -534,7 +534,7 @@ def display_counter():
 @click.option(
     "--start-date",
     type=datetime_type,
-    default="1900-1-1",
+    default="1970-1-1",
     help="Only considers books added to library on or after this UTC date."
 )
 @click.option(

--- a/src/audible_cli/cmds/cmd_library.py
+++ b/src/audible_cli/cmds/cmd_library.py
@@ -111,7 +111,7 @@ async def export_library(session, client, **params):
 
     keys_with_raw_values = (
         "asin", "title", "subtitle", "extended_product_description", "runtime_length_min", "is_finished",
-        "percent_complete", "release_date"
+        "percent_complete", "release_date", "purchase_date"
     )
 
     prepared_library = await asyncio.gather(
@@ -129,7 +129,7 @@ async def export_library(session, client, **params):
             "asin", "title", "subtitle", "extended_product_description", "authors", "narrators", "series_title",
             "series_sequence", "genres", "runtime_length_min", "is_finished",
             "percent_complete", "rating", "num_ratings", "date_added",
-            "release_date", "cover_url"
+            "release_date", "cover_url", "purchase_date"
         )
 
         export_to_csv(output_filename, prepared_library, headers, dialect)


### PR DESCRIPTION
Provide an RFC 3339 formatted date as a string, and only download items purchased after that date.
Also added the purchase date to the list of values generated by ```audible library export```.

I added this so it's easier to programmatically download new books without worrying about what's already been downloaded.