### PR TITLE
Add `-c, --remove-intro-outro` option to `decrypt`

### DIFF
--- a/plugin_cmds/cmd_decrypt.py
+++ b/plugin_cmds/cmd_decrypt.py
@@ -487,12 +487,6 @@ class FfmpegFileDecrypter:
                 quote(self._credentials),
             ]    
         base_cmd.extend(credentials_cmd)
-        base_cmd.extend(
-            [
-                "-i",
-                quote(str(self._source)),
-            ]
-        )
 
         if self._rebuild_chapters:
             metafile = _get_ffmeta_file(self._source, self._tempdir)
@@ -510,12 +504,14 @@ class FfmpegFileDecrypter:
 
                     base_cmd.extend(
                         [
-                            "-i",
-                            quote(str(metafile)),
                             "-ss",
                             f"{start_new}ms",
                             "-t",
                             f"{duration_new}ms",
+                            "-i",
+                            quote(str(self._source)),
+                            "-i",
+                            quote(str(metafile)),
                             "-map_metadata",
                             "0",
                             "-map_chapters",
@@ -533,6 +529,13 @@ class FfmpegFileDecrypter:
                             "1",
                         ]
                     )
+        else:
+            base_cmd.extend(
+                [
+                    "-i",
+                    quote(str(self._source)),
+                ]
+            )
 
         base_cmd.extend(
             [


### PR DESCRIPTION
This adds a `-c, --remove-intro-outro` option to the `decrypt` subcommand that removes the Audible brand intro and outro. It can't be used together with the `-s, --separate-intro-outro` option.

I mainly followed the example in the [wiki](https://trac.ffmpeg.org/wiki/Seeking#Cuttingsmallsections). I chose `-t` with a duration instead of `-to` with a timestamp, because it doesn't depend on the location of `-ss` with respect to `-i`. `-ss` resets the timestamps to 0 if it's before `-i` but not if it's after. `-t` continues to work the same, while `-to` would need to adapt.

Closes #170.