### PR TITLE
Fix badly encoded characters in metadata

### DIFF
--- a/plugin_cmds/cmd_decrypt.py
+++ b/plugin_cmds/cmd_decrypt.py
@@ -467,7 +467,6 @@ class FfmpegFileDecrypter:
             metafile = _get_ffmeta_file(self._source, self._tempdir)
             try:
                 self.rebuild_chapters()
-                self.ffmeta.write(metafile)
             except ChapterError:
                 if self._skip_rebuild_chapters:
                     echo("Skip rebuild chapters due to chapter mismatch.")
@@ -492,6 +491,8 @@ class FfmpegFileDecrypter:
                 quote(str(outfile)),
             ]
         )
+
+        self.ffmeta.write(metafile)
 
         subprocess.check_output(base_cmd, text=True)  # noqa: S603
 

--- a/plugin_cmds/cmd_decrypt.py
+++ b/plugin_cmds/cmd_decrypt.py
@@ -227,7 +227,13 @@ class FFMeta:
                     cursec = parsed_dict[sec_name] = {}
             else:
                 match = self.OPTION.match(line)
-                cursec.update({match.group("option"): match.group("value")})
+                option = match.group("option")
+                value = match.group("value")
+                # manually fix badly encoded characters
+                if option == "copyright":
+                    value = re.sub(r'&\\#169\\;(null )?', '©', value)
+                    value = re.sub(r'\s*\\;\(P\)', ' (P)', value)
+                cursec.update({option: value})
 
         return parsed_dict
 


### PR DESCRIPTION
This is an attempt to fix badly encoded characters in the AAX/C metadata. I'm not sure what encoding the AAX/C format uses for metadata and what badly encoded characters Audible has throughout its library. Hence this is currently a limited "find and replace" for those characters I've encountered. Please feel free to add more if you find them.

Specifically, this currently fixes:
- in "copyright":
  - copyright character `©` from some doubly escaped HTML entity `&\#169\;` potentially followed by `null `.
  - producer string `(P)` (does it mean that?) from some unknown escape `\;(P)` with missing or multiple preceding whitespaces.

EDIT: This doesn't seem to work yet. Not sure why. The updated metadata should be written to the temporary metadata file. I suspected that ffmpeg, the .m4b format or the file metadata doesn't support Unicode, but one of my audiobooks has the correct copyright character already, which suggests this should not be the issue.