### PR TITLE
Rework flat chapter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - The `--chapter-type` option is added to the download command. Chapter can now be 
-  downloaded as `flat` or `tree` type. `tree` is the default.
+  downloaded as `flat` or `tree` type. `tree` is the default. A default chapter type 
+  can be set in the config file.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ The APP section supports the following options:
 - primary_profile: The profile to use, if no other is specified
 - filename_mode: When using the `download` command, a filename mode can be 
   specified here. If not present, "ascii" will be used as default. To override
-  these option, you can provide a mode with the `filename-mode` option of the
+  these option, you can provide a mode with the `--filename-mode` option of the
+  download command.
+- chapter_type: When using the `download` command, a chapter type can be specified 
+  here. If not present, "tree" will be used as default. To override
+  these option, you can provide a type with the `--chapter-type` option of the
   download command.
 
 #### Profile section
@@ -162,6 +166,7 @@ The APP section supports the following options:
 - auth_file: The auth file for this profile
 - country_code: The marketplace for this profile
 - filename_mode: See APP section above. Will override the option in APP section.
+- chapter_type: See APP section above. Will override the option in APP section.
 
 ## Getting started
 

--- a/src/audible_cli/_version.py
+++ b/src/audible_cli/_version.py
@@ -1,7 +1,7 @@
 __title__ = "audible-cli"
 __description__ = "Command line interface (cli) for the audible package."
 __url__ = "https://github.com/mkb79/audible-cli"
-__version__ = "0.3.2b2"
+__version__ = "0.3.2b3"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -226,7 +226,7 @@ async def download_chapters(
     metadata = json.dumps(metadata, indent=4)
     async with aiofiles.open(file, "w") as f:
         await f.write(metadata)
-    logger.info(f"Chapter file saved to {file}.")
+    logger.info(f"Chapter file saved in style '{chapter_type.upper()}' to {file}.")
     counter.count_chapter()
 
 
@@ -291,6 +291,7 @@ async def _add_audioparts_to_queue(
             get_pdf=None,
             get_annotation=None,
             get_chapters=None,
+            chapter_type=None,
             get_aax=get_aax,
             get_aaxc=get_aaxc,
             client=client,
@@ -688,12 +689,12 @@ def display_counter():
 @click.option(
     "--chapter",
     is_flag=True,
-    help="saves chapter metadata as JSON file"
+    help="Saves chapter metadata as JSON file."
 )
 @click.option(
     "--chapter-type",
-    default="Tree",
-    type=click.Choice(["Flat", "Tree"], case_sensitive=False),
+    default="config",
+    type=click.Choice(["Flat", "Tree", "config"], case_sensitive=False),
     help="The chapter type."
 )
 @click.option(
@@ -788,7 +789,6 @@ async def cli(session, api_client, **params):
     cover_sizes = list(set(params.get("cover_size")))
     overwrite_existing = params.get("overwrite")
     ignore_errors = params.get("ignore_errors")
-    chapter_type = params.get("chapter_type")
     no_confirm = params.get("no_confirm")
     resolve_podcats = params.get("resolve_podcasts")
     ignore_podcasts = params.get("ignore_podcasts")
@@ -811,6 +811,11 @@ async def cli(session, api_client, **params):
         logger.info(
             f"Selected end date: {end_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
         )
+
+    chapter_type = params.get("chapter_type")
+    if chapter_type == "config":
+        chapter_type = session.config.get_profile_option(
+            session.selected_profile, "chapter_type") or "Tree"
 
     filename_mode = params.get("filename_mode")
     if filename_mode == "config":

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -394,6 +394,7 @@ class LibraryItem(BaseItem):
     async def get_content_metadata(
         self, quality: str = "high", chapter_type: str = "Tree", **request_kwargs
     ):
+        chapter_type = chapter_type.capitalize()
         assert quality in ("best", "high", "normal",)
         assert chapter_type in ("Flat", "Tree")
 


### PR DESCRIPTION
This PR adds the ability to set a default chapter type in the config file. This allows the user to specify whether chapters should be downloaded as `flat` or `tree` type without having to state it each time a download command is given.
