### PR TITLE
fix: decrypt command filename escape

### DIFF
--- a/plugin_cmds/cmd_decrypt.py
+++ b/plugin_cmds/cmd_decrypt.py
@@ -19,7 +19,6 @@ import typing as t
 from enum import Enum
 from functools import reduce
 from glob import glob
-from shlex import quote
 from shutil import which
 
 import click
@@ -385,20 +384,20 @@ class FfmpegFileDecrypter:
                 key, iv = self._credentials
                 credentials_cmd = [
                     "-audible_key",
-                    quote(key),
+                    key,
                     "-audible_iv",
-                    quote(iv),
+                    iv,
                 ]
             else:
                 credentials_cmd = [
                     "-activation_bytes",
-                    quote(self._credentials),
+                    self._credentials,
                 ]    
             base_cmd.extend(credentials_cmd)
     
             extract_cmd = [
                 "-i",
-                quote(str(self._source)),
+                str(self._source),
                 "-f",
                 "ffmetadata",
                 str(metafile),
@@ -440,20 +439,20 @@ class FfmpegFileDecrypter:
             key, iv = self._credentials
             credentials_cmd = [
                 "-audible_key",
-                quote(key),
+                key,
                 "-audible_iv",
-                quote(iv),
+                iv,
             ]
         else:
             credentials_cmd = [
                 "-activation_bytes",
-                quote(self._credentials),
+                self._credentials,
             ]    
         base_cmd.extend(credentials_cmd)
         base_cmd.extend(
             [
                 "-i",
-                quote(str(self._source)),
+                str(self._source),
             ]
         )
 
@@ -471,7 +470,7 @@ class FfmpegFileDecrypter:
                 base_cmd.extend(
                     [
                         "-i",
-                        quote(str(metafile)),
+                        str(metafile),
                         "-map_metadata",
                         "0",
                         "-map_chapters",
@@ -483,7 +482,7 @@ class FfmpegFileDecrypter:
             [
                 "-c",
                 "copy",
-                quote(str(outfile)),
+                str(outfile),
             ]
         )
 


### PR DESCRIPTION
`subprocess.check_output()` is not called with the option `shell = True` so it doesn't make sense to escape any arguments because ffmpeg will already receive them as is.

When e.g. a filename contains escapable characters, then the `quote()` function encloses the it with quotation marks ''. FFmpeg interprets those literally and they don't match any file (the actual file doesn't start with ').

Here is the error that this PR fixes:

```shell
❯ audible --verbosity DEBUG --profile de decrypt --all --rebuild-chapters --force-rebuild-chapters
debug: Audible-cli version: 0.3.1
debug: App dir: /root/.audible
debug: Plugin dir: /root/dev/audible-cli/plugin_cmds
debug: Config loaded from config.toml
debug: Auth file de.json for profile de loaded.
ffmpeg version 5.1.2-0ubuntu1~20.04.sav1 Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
  configuration: --prefix=/usr --extra-version='0ubuntu1~20.04.sav1' --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-gnutls --enable-ladspa --enable-lcms2 --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-sndio --enable-pocketsphinx --enable-librsvg --enable-libdav1d --enable-libjxl --enable-librist --enable-libvmaf --enable-libzimg --enable-crystalhd --enable-libmfx --enable-libsvtav1 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-libplacebo --enable-librav1e --enable-shared
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
'A_Redacted_Book_Name_(that_Contains_Parentheses)_(Some_Editor)-AAX_44_128.aaxc': No such file or directory
Uncaught Exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/audible_cli/cli.py", line 60, in main
    sys.exit(cli(*args, **kwargs))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/root/dev/audible-cli/plugin_cmds/cmd_decrypt.py", line 608, in cli
    decrypter.run()
  File "/root/dev/audible-cli/plugin_cmds/cmd_decrypt.py", line 463, in run
    self.rebuild_chapters()
  File "/root/dev/audible-cli/plugin_cmds/cmd_decrypt.py", line 415, in rebuild_chapters
    self.ffmeta.update_chapters_from_chapter_info(
  File "/root/dev/audible-cli/plugin_cmds/cmd_decrypt.py", line 408, in ffmeta
    subprocess.check_output(base_cmd, text=True)  # noqa: S603
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ffmpeg', '-stats', '-audible_key', '0123456789abcdef0123456789abcdef, '-audible_iv', '9876543210fedcba9876543210fedcba', '-i', "'A_Redacted_Book_Name_(that_Contains_Parentheses)_(Some_Editor)-AAX_44_128.aaxc'", '-f', 'ffmetadata', '/root/audible-backup-library/tmp/audible/de/A_Redacted_Book_Name_(that_Contains_Parentheses)_(Some_Editor)-AAX_44_128.meta']' returned non-zero exit status 1.
```

In this example `ffmpeg` incorrectly looks for the file `'A_Redacted_Book_Name_(that_Contains_Parentheses)_(Some_Editor)-AAX_44_128.aaxc'` that doesn't exist. The actual file is `A_Redacted_Book_Name_(that_Contains_Parentheses)_(Some_Editor)-AAX_44_128.aaxc` and it shouldn't have been quoted.