### PR TITLE
fix: plugin decrypt rebuild-chapters without -c

### DIFF
--- a/plugin_cmds/cmd_decrypt.py
+++ b/plugin_cmds/cmd_decrypt.py
@@ -521,6 +521,8 @@ class FfmpegFileDecrypter:
                     base_cmd.extend(
                         [
                             "-i",
+                            str(self._source),
+                            "-i",
                             str(metafile),
                             "-map_metadata",
                             "0",


### PR DESCRIPTION
The call with `audible-cli decryt --overwrite --rebuild-chapters --force-rebuild-chapters` was broken due to a missing input file. There is no issue if the `-c` option is used, as this included the input file.