### PR TITLE
fix: Update file path type in wishlist export command #219

### DIFF
--- a/src/audible_cli/cmds/cmd_wishlist.py
+++ b/src/audible_cli/cmds/cmd_wishlist.py
@@ -41,7 +41,7 @@ def cli():
 @cli.command("export")
 @click.option(
     "--output", "-o",
-    type=click.Path(),
+    type=click.Path(path_type=pathlib.Path),
     default=pathlib.Path().cwd() / r"wishlist.{format}",
     show_default=True,
     help="output file"


### PR DESCRIPTION
Modified the `--output` option to use `pathlib.Path` for type safety and consistency. This ensures better integration with modern Python path handling.