### PR TITLE
Shell Completion: Fix fish completion

### DIFF
--- a/utils/code_completion/README.md
+++ b/utils/code_completion/README.md
@@ -5,5 +5,5 @@ Tab completion can be provided for commands, options and choice values.
 Bash, Zsh and Fish are supported.
 
 Simply copy the activation script for your shell from this folder to your machine. 
-Read [here](https://click.palletsprojects.com/en/8.0.x/shell-completion/) 
+Read [here](https://click.palletsprojects.com/en/stable/shell-completion/) 
 how-to activate the script in your shell. 

--- a/utils/code_completion/audible-complete-fish.sh
+++ b/utils/code_completion/audible-complete-fish.sh
@@ -1,0 +1,2 @@
+_AUDIBLE_COMPLETE=fish_source audible
+_AUDIBLE_QUICKSTART_COMPLETE=fish_source audible-quickstart

--- a/utils/code_completion/audible-complete-zsh-fish.sh
+++ b/utils/code_completion/audible-complete-zsh-fish.sh
@@ -1,2 +1,5 @@
+echo "WARNING: audible-complete-zsh-fish.sh is deprecated." >&2
+echo "         Please use audible-complete-zsh.sh for zsh," >&2
+echo "         and audible-complete-fish.sh for fish." >&2
 _AUDIBLE_COMPLETE=zsh_source audible
 _AUDIBLE_QUICKSTART_COMPLETE=zsh_source audible-quickstart

--- a/utils/code_completion/audible-complete-zsh.sh
+++ b/utils/code_completion/audible-complete-zsh.sh
@@ -1,0 +1,2 @@
+_AUDIBLE_COMPLETE=zsh_source audible
+_AUDIBLE_QUICKSTART_COMPLETE=zsh_source audible-quickstart


### PR DESCRIPTION
Fish and zsh have completely different syntax, and using a zsh file for fish only generates syntax errors.  `shell-completion` already supports fish, so it is an easy fix.

It would be reasonable to rename `audible-complete-zsh-fish.sh` to `audible-complete-zsh.sh` directly.  But for people using `audible-complete-zsh-fish.sh` for zsh, this may break their completion until they update the file path.

On the other hand, if not informed, those users may never move to the new file and `audible-complete-zsh-fish.sh` can never be deleted.  So, a warning is added, hopefully, it would not break anything.