### PR TITLE
docs: link testers to audible-rs Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 > the command line and don't mind occasional breakage, please help kick the
 > tyres → **[github.com/mkb79/audible-rs](https://github.com/mkb79/audible-rs)**
 > (the README there has a one-line installer for prebuilt Linux/macOS binaries).
+> Share feedback, questions and findings in the
+> **[audible-rs Discussions](https://github.com/mkb79/audible-rs/discussions)**.
 >
 > `audible-cli` stays fully supported — audible-rs is the future direction,
 > not an immediate replacement, and the two use separate config directories,


### PR DESCRIPTION
Follow-up to #261 (which merged before this line was added): points the audible-rs tester notice at the newly-enabled **[Discussions](https://github.com/mkb79/audible-rs/discussions)** so feedback lands in one place. Two-line docs change.