### PR TITLE
fix: accept API timestamps with and without fractional seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Accept API timestamps with and without fractional seconds, fixing the `--start-date`/`--end-date` crash on podcast episodes and the mirror-image crash in `is_published()` (#264)
+
 ## [0.4.0] - 2026-07-20
 
 ### Added

--- a/plugin_cmds/cmd_goodreads-transform.py
+++ b/plugin_cmds/cmd_goodreads-transform.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from datetime import datetime, timezone
+from datetime import timezone
 
 import click
 from audible_cli.decorators import (
@@ -10,7 +10,7 @@ from audible_cli.decorators import (
     pass_session
 )
 from audible_cli.models import Library
-from audible_cli.utils import export_to_csv
+from audible_cli.utils import export_to_csv, parse_api_datetime
 from isbntools.app import isbn_from_words
 
 
@@ -85,9 +85,9 @@ def _prepare_library_for_export(library):
         date_added = i.library_status
         if date_added is not None:
             date_added = date_added["date_added"]
-            date_added = datetime.strptime(
-                date_added, '%Y-%m-%dT%H:%M:%S.%fZ'
-            ).replace(tzinfo=timezone.utc).astimezone()    
+            date_added = parse_api_datetime(date_added).replace(
+                tzinfo=timezone.utc
+            )
             date_added = date_added.astimezone().date().isoformat()
 
         date_read = None

--- a/src/audible_cli/exceptions.py
+++ b/src/audible_cli/exceptions.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from pathlib import Path
 
+from .utils import parse_api_datetime
+
 
 class AudibleCliException(Exception):
     """Base class for all errors"""
@@ -76,7 +78,7 @@ class ItemNotPublished(AudibleCliException):
     """Raised if a voucher reached his refresh date"""
 
     def __init__(self, asin: str, pub_date):
-        pub_date = datetime.strptime(pub_date, "%Y-%m-%dT%H:%M:%SZ")
+        pub_date = parse_api_datetime(pub_date)
         now = datetime.utcnow()
         published_in = pub_date - now
 

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -21,7 +21,7 @@ from .exceptions import (
     NotDownloadableAsAAX,
     ItemNotPublished
 )
-from .utils import full_response_callback, LongestSubString
+from .utils import full_response_callback, LongestSubString, parse_api_datetime
 
 
 logger = logging.getLogger("audible_cli.models")
@@ -146,9 +146,7 @@ class BaseItem:
             publication_datetime = self.publication_datetime
 
         if publication_datetime is not None:
-            pub_date = datetime.strptime(
-                publication_datetime, "%Y-%m-%dT%H:%M:%SZ"
-            )
+            pub_date = parse_api_datetime(publication_datetime)
             now = datetime.utcnow()
             return now > pub_date
 
@@ -502,14 +500,10 @@ class Library(BaseList):
     ):
         def filter_by_date(item):
             if item.purchase_date is not None:
-                date_added = datetime.strptime(
-                    item.purchase_date,
-                    "%Y-%m-%dT%H:%M:%S.%fZ"
-                )
+                date_added = parse_api_datetime(item.purchase_date)
             elif item.library_status.get("date_added") is not None:
-                date_added = datetime.strptime(
-                    item.library_status.get("date_added"),
-                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                date_added = parse_api_datetime(
+                    item.library_status.get("date_added")
                 )
             else:
                 logger.info(

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -2,6 +2,7 @@ import csv
 import io
 import logging
 import pathlib
+from datetime import datetime
 from difflib import SequenceMatcher
 from typing import List, Optional, Union
 
@@ -28,6 +29,34 @@ datetime_type = click.DateTime([
     "%Y-%m-%dT%H:%M:%S.%fZ",
     "%Y-%m-%dT%H:%M:%SZ"
 ])
+
+API_DATETIME_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%fZ",
+    "%Y-%m-%dT%H:%M:%SZ"
+)
+
+
+def parse_api_datetime(value: str) -> datetime:
+    """Parse a timestamp as returned by the Audible API.
+
+    The API uses both variants, with and without fractional seconds
+    (``2019-11-29T11:40:49.000Z`` vs. ``2019-11-29T11:40:49Z``), sometimes
+    for the same field. Top-level library items usually carry the fraction,
+    child episodes of a podcast usually do not, so both have to be accepted.
+
+    Raises:
+        ValueError: If the value matches none of the known formats.
+    """
+    for fmt in API_DATETIME_FORMATS:
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+
+    raise ValueError(
+        f"time data {value!r} does not match any known API datetime "
+        f"format {API_DATETIME_FORMATS}"
+    )
 
 
 def prompt_captcha_callback(captcha_url: str) -> str:


### PR DESCRIPTION
Fixes #264.

## Problem

`--start-date` / `--end-date` crash with a `ValueError` as soon as the library contains a podcast whose episodes carry a `purchase_date` **without** fractional seconds:

```
ValueError: time data '2019-11-29T11:40:49Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

The API returns both shapes, sometimes for the same field:

* `2019-11-29T11:40:49.000Z` — top-level library items
* `2019-11-29T11:40:49Z` — podcast child episodes returned by `get_child_items()`

Every API timestamp was parsed with a single hardcoded format, so each call site broke on exactly the shape it did not expect:

| Call site | Hardcoded format | Breaks on |
| --- | --- | --- |
| `models.py` — `filter_by_date()`, `purchase_date` | `%Y-%m-%dT%H:%M:%S.%fZ` | timestamps **without** a fraction |
| `models.py` — `filter_by_date()`, `library_status["date_added"]` | `%Y-%m-%dT%H:%M:%S.%fZ` | timestamps **without** a fraction |
| `models.py` — `is_published()` | `%Y-%m-%dT%H:%M:%SZ` | timestamps **with** a fraction |
| `exceptions.py` — `ItemNotPublished` | `%Y-%m-%dT%H:%M:%SZ` | timestamps **with** a fraction |
| `plugin_cmds/cmd_goodreads-transform.py` — `date_added` | `%Y-%m-%dT%H:%M:%S.%fZ` | timestamps **without** a fraction |

The last two rows are the mirror image of the reported bug: they only accept the fraction-less shape. Fixing `is_published()` alone would just move the crash into `ItemNotPublished`, so both had to change together.

`utils.datetime_type` (the click type behind the `--start-date` option itself) already accepted both variants — only the parsing of API responses was strict.

## Fix

A shared `parse_api_datetime()` helper in `utils.py` that accepts both variants, used at all five sites. It still raises `ValueError` on genuinely unparseable input rather than returning `None`, so an unexpected third format stays visible instead of being silently swallowed by the date filter.

The helper deliberately returns **naive** datetimes, matching what `datetime_type` produces and what `datetime.utcnow()` is compared against, so this change is contained to the parsing itself.

## Verification

A repro harness rebuilds the crash chain from the issue against a fake API client — `Library.from_api()` with mixed timestamp shapes, plus both shapes for `is_published()` and `ItemNotPublished`:

* **Patched:** all five sites pass; the date filter keeps the correct 4 of 5 items (a 2007 item is correctly dropped by `--start-date 2008-01-01`).
* **Unpatched (same harness, changes stashed):** reproduces exactly the `ValueError` from the issue traceback.

Also checked:

* No import cycle from the new `exceptions.py` → `utils.py` import (`utils` only pulls in `constants`); verified by importing `audible_cli.exceptions` in isolation.
* `ruff check src plugin_cmds`: 434 → 432 findings, no new ones. (The two that disappear are a stray single-quote string and trailing whitespace in the Goodreads plugin.)

## Out of scope

Deliberately left for a follow-up PR, since they are refactors rather than fixes and would change public behaviour:

* Migrating to `datetime.fromisoformat()` and timezone-aware UTC values throughout. That has to be done atomically — comparing naive against aware datetimes raises `TypeError` — and it changes what `utils.datetime_type` hands back to external users.
* Replacing the `datetime.utcnow()` / `datetime.utcfromtimestamp()` calls that are deprecated since Python 3.12 (`models.py`, `exceptions.py`, and two more in `cmd_download.py`).

Unrelated, noticed while working on this: `--end-date 2019-11-29` is parsed as `00:00:00`, so "on or before this UTC date" currently means the *start* of that day rather than the end.
