### PR TITLE
fix: pass config path to click.edit as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Skip the voucher refresh check when `refresh_date` is empty or null rather than only when the key is absent, instead of raising a `TypeError` (#268)
 - Treat an unknown `publication_datetime` as published rather than crashing, and let `ItemNotPublished` report the ASIN without a countdown when no usable date is available (#268)
 - Reach `LicenseDenied` and `NoDownloadUrl` as intended when `license_denial_reasons`, `content_metadata` or `content_url` are null, instead of raising a `TypeError` or `AttributeError` (#268)
+- `audible manage config edit` no longer crashes with `TypeError: 'PosixPath' object is not iterable`; `click.edit()` accepts a `str` or an iterable of them, but not a `pathlib.Path` (#248)
 
 ## [0.4.0] - 2026-07-20
 

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 
 import click
@@ -38,7 +39,7 @@ def manage_auth_files():
 @pass_session
 def config_editor(session):
     """Open the config file with default editor"""
-    click.edit(filename=session.config.filename)
+    click.edit(filename=os.fspath(session.config.filename))
 
 
 @manage_profiles.command("list")

--- a/tests/test_cmd_manage.py
+++ b/tests/test_cmd_manage.py
@@ -1,0 +1,25 @@
+import os
+import pathlib
+from unittest import mock
+
+from click.testing import CliRunner
+
+from audible_cli.cmds.cmd_manage import cli
+from audible_cli.config import Session
+
+
+def test_config_edit_passes_str_path_to_click_edit(tmp_path):
+    """Click >= 8.2 takes a `str` or an iterable of them, but not a `Path`."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[APP]\n")
+
+    session = Session()
+    session._config = mock.Mock(filename=pathlib.Path(config_file))
+
+    runner = CliRunner()
+    with mock.patch("audible_cli.cmds.cmd_manage.click.edit") as edit:
+        result = runner.invoke(cli, ["config", "edit"], obj=session)
+
+    assert result.exit_code == 0, result.output
+    edit.assert_called_once_with(filename=os.fspath(config_file))
+    assert isinstance(edit.call_args.kwargs["filename"], str)


### PR DESCRIPTION
Closes #248

`audible manage config edit` passed the `pathlib.Path` from `session.config.filename` to `click.edit(filename=...)`. Click >= 8.2 hands that value straight to `Editor.edit_files()`, which iterates it, so the command aborted with `TypeError: 'WindowsPath' object is not iterable`. Converting with `os.fspath()` fixes it — this is the approach you outlined on the issue.

Added `tests/test_cmd_manage.py`, which asserts the filename reaching `click.edit` is a string; it fails on the current code and passes with the fix. Also added a CHANGELOG entry under Unreleased/Fixed.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
