### PR TITLE
fix: handle missing and null fields in API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Accept API timestamps with and without fractional seconds, fixing the `--start-date`/`--end-date` crash on podcast episodes and the mirror-image crash in `is_published()` (#264)
+- Keep items whose date cannot be determined instead of crashing with an `AttributeError`, when a date filter is active and an item carries no `library_status` (#268)
+- Skip the voucher refresh check when `refresh_date` is empty or null rather than only when the key is absent, instead of raising a `TypeError` (#268)
+- Treat an unknown `publication_datetime` as published rather than crashing, and let `ItemNotPublished` report the ASIN without a countdown when no usable date is available (#268)
+- Reach `LicenseDenied` and `NoDownloadUrl` as intended when `license_denial_reasons`, `content_metadata` or `content_url` are null, instead of raising a `TypeError` or `AttributeError` (#268)
 
 ## [0.4.0] - 2026-07-20
 

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -389,7 +389,8 @@ async def _reuse_voucher(lr_file, item):
             logger.debug(f"{lr_file} does not contain allowed users key.")
 
     # Verification of voucher validity
-    if "refresh_date" in content_license:
+    # Test the value, not just the key: the field can be present but null
+    if content_license.get("refresh_date"):
         refresh_date = content_license["refresh_date"]
         refresh_date = datetime_type.convert(refresh_date, None, None)
         if refresh_date < datetime.now(UTC):

--- a/src/audible_cli/exceptions.py
+++ b/src/audible_cli/exceptions.py
@@ -78,7 +78,15 @@ class ItemNotPublished(AudibleCliException):
     """Raised if a voucher reached his refresh date"""
 
     def __init__(self, asin: str, pub_date):
-        pub_date = parse_api_datetime(pub_date)
+        # Never fail while building an error message. Without a usable
+        # publication date there is no countdown to report, but the item is
+        # still worth naming.
+        try:
+            pub_date = parse_api_datetime(pub_date)
+        except (ValueError, OverflowError):
+            super().__init__(f"{asin} is not published.")
+            return
+
         now = datetime.now(UTC)
         published_in = pub_date - now
 

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -142,18 +142,29 @@ class BaseItem:
                 return True
 
     def is_published(self):
+        publication_datetime = None
         if (
             self.content_delivery_type and self.content_delivery_type == "AudioPart"
             and self._parent
         ):
             publication_datetime = self._parent.publication_datetime
-        else:
+
+        # A part without a parent date can still carry its own one
+        if publication_datetime is None:
             publication_datetime = self.publication_datetime
 
-        if publication_datetime is not None:
-            pub_date = parse_api_datetime(publication_datetime)
-            now = datetime.now(UTC)
-            return now > pub_date
+        if publication_datetime is None:
+            # No publication date means unknown, not unpublished. Skipping the
+            # item on absent evidence would silently drop it, so let the
+            # download attempt itself decide.
+            logger.debug(
+                f"{self.asin}: no publication date, assuming it is published."
+            )
+            return True
+
+        pub_date = parse_api_datetime(publication_datetime)
+        now = datetime.now(UTC)
+        return now > pub_date
 
 
 class LibraryItem(BaseItem):
@@ -367,7 +378,7 @@ class LibraryItem(BaseItem):
         content_license = lr["content_license"]
 
         if content_license["status_code"] == "Denied":
-            if "license_denial_reasons" in content_license:
+            if content_license.get("license_denial_reasons"):
                 for reason in content_license["license_denial_reasons"]:
                     message = reason.get("message", "UNKNOWN")
                     rejection_reason = reason.get("rejectionReason", "UNKNOWN")
@@ -381,8 +392,8 @@ class LibraryItem(BaseItem):
             msg = content_license["message"]
             raise LicenseDenied(msg)
 
-        content_url = content_license["content_metadata"]\
-            .get("content_url", {}).get("offline_url")
+        content_metadata = content_license.get("content_metadata") or {}
+        content_url = (content_metadata.get("content_url") or {}).get("offline_url")
         if content_url is None:
             raise NoDownloadUrl(self.asin)
 
@@ -511,12 +522,13 @@ class Library(BaseList):
             end_date = to_utc_datetime(end_date)
 
         def filter_by_date(item):
+            # Items from a partial response can miss both fields entirely, and
+            # library_status can be null instead of a dict
+            library_status = item.library_status or {}
             if item.purchase_date is not None:
                 date_added = parse_api_datetime(item.purchase_date)
-            elif item.library_status.get("date_added") is not None:
-                date_added = parse_api_datetime(
-                    item.library_status.get("date_added")
-                )
+            elif library_status.get("date_added") is not None:
+                date_added = parse_api_datetime(library_status["date_added"])
             else:
                 logger.info(
                     f"{item.asin}: {item.full_title} can not determine date added."


### PR DESCRIPTION
Closes #268.

## Problem

Five crashes sharing one root pattern: the code assumes a field is present and non-null in an API response, and raises an unhelpful low-level exception when it is not.

| Where | Trigger | Was |
| --- | --- | --- |
| `filter_by_date()` | `purchase_date: null` + missing/null `library_status`, with any date bound | `AttributeError: 'NoneType' object has no attribute 'get'` |
| `_reuse_voucher()` | `refresh_date: null` | `TypeError: strptime() argument 1 must be str, not None` |
| `get_license()` | `license_denial_reasons: null` on a denied license | `TypeError: 'NoneType' object is not iterable` instead of `LicenseDenied` |
| `get_license()` | `content_metadata: null` or `content_url: null` | `AttributeError` instead of `NoDownloadUrl` |
| `is_published()` | missing `publication_datetime` | falls through to `None`, callers pass it to `ItemNotPublished`, which fails in the parser |

The first three rows all come from testing key presence where the value needed testing. Case 1 is reachable in practice: podcast episodes fetched through the catalog endpoint carry neither `purchase_date` nor `library_status` (#267).

## Behaviour change

A missing `publication_datetime` now means **unknown**, not **unpublished**. Skipping an item on absent evidence silently drops content, so `is_published()` returns `True` and lets the download attempt itself decide. An `AudioPart` whose parent carries no publication date falls back to its own date, so a known future date is still honoured — only when neither is available is the item assumed published.

`ItemNotPublished` no longer raises while building its message; without a usable date it reports the ASIN without a countdown.

## Verification

* `library_status` missing / null / `date_added` null — all three keep the item; the `date_added` branch still filters correctly
* `refresh_date` null and absent are skipped; expired → `VoucherNeedRefresh`, valid → accepted, expired `Expires` → `DownloadUrlExpired` all unchanged
* `license_denial_reasons` null → `LicenseDenied`; `content_metadata`/`content_url` null → `NoDownloadUrl`; a denied license with real reasons is unchanged
* `is_published()` across the parent/child matrix — parent date stays authoritative, fallback only when the parent has none, both absent → `True`; non-`AudioPart` unchanged
* `ItemNotPublished` with `None`, `""`, `"garbage"` and an overflowing offset → clean message; a real date still yields the countdown
* The timezone-aware suite from #266 still passes
* `ruff check src plugin_cmds`: +1 `G004` for the new `logger.debug` f-string, matching the six already in that file
* Real API: `audible library list --resolve-podcasts --start-date 2008-01-01` against an account with 168 titles returns 914 items, identical to `master` in the same window, exit 0, no stderr

## Review notes

A review pass caught a regression in the first version of the `is_published()` change: returning `True` on a null parent date ignored a valid future date on the child. That is fixed and covered by the parent/child matrix above. The same pass found the two `get_license()` cases, which are the same defect class as the three in #268 and are therefore included here rather than deferred to another issue.

Two related items deliberately left out, both pre-existing:

* Callers pass `self.publication_datetime` to `ItemNotPublished` even when `is_published()` evaluated the *parent's* date, so a future parent with a past child can produce a misleading countdown.
* The bundled example plugins carry similar null assumptions (`library_status["date_added"]` in `cmd_goodreads-transform.py`, `product_images.items()` in `cmd_image-urls.py`). Not built-in command paths.
