### PR TITLE
fix: stop the download queue from deadlocking after failed jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - API timestamps, library date filters and voucher deadlines are now timezone-aware UTC; naive `--start-date`/`--end-date` input is interpreted as UTC, as the option help already stated (#266)
 - Replaced `datetime.utcnow()` and `datetime.utcfromtimestamp()`, deprecated since Python 3.12 (#266)
+- Without `--ignore-errors`, the download command now really aborts on the first failure: running downloads finish, queued ones are skipped (#235)
+- The download command exits non-zero when a download job raised an error, also with `--ignore-errors`. Failures that are only logged, such as an unknown ASIN or a download rejected by its HTTP status, still exit zero for now (#256)
+- `--jobs` now rejects values below 1 instead of accepting `0`, which queued work that no consumer would ever pick up (#235)
 
 ### Fixed
 
@@ -23,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Treat an unknown `publication_datetime` as published rather than crashing, and let `ItemNotPublished` report the ASIN without a countdown when no usable date is available (#268)
 - Reach `LicenseDenied` and `NoDownloadUrl` as intended when `license_denial_reasons`, `content_metadata` or `content_url` are null, instead of raising a `TypeError` or `AttributeError` (#268)
 - `audible manage config edit` no longer crashes with `TypeError: 'PosixPath' object is not iterable`; `click.edit()` accepts a `str` or an iterable of them, but not a `pathlib.Path` (#248)
+- The download command no longer hangs forever after failed downloads. A failing job killed its consumer, and once every `--jobs` consumer had died the queue was never drained (#235, #239)
 
 ## [0.4.0] - 2026-07-20
 

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -502,17 +502,89 @@ async def download_aaxc(
         )
 
 
-async def consume(ignore_errors):
+class DownloadRun:
+    """Tracks failures across all consumers of a single download run."""
+
+    def __init__(self, ignore_errors: bool):
+        self.ignore_errors = ignore_errors
+        # Set as soon as a job fails while --ignore-errors is not in effect
+        self.abort = asyncio.Event()
+        self.errors: list[Exception] = []
+        # Jobs dropped without running because the run was aborted
+        self.skipped = 0
+
+    def record(self, error: Exception) -> None:
+        self.errors.append(error)
+        if not self.ignore_errors:
+            # Let running downloads finish, but start no new ones
+            self.abort.set()
+
+    def raise_for_errors(self) -> None:
+        if not self.errors:
+            return
+
+        msg = f"{len(self.errors)} job(s) failed"
+        if self.skipped:
+            msg += f", {self.skipped} skipped after the abort"
+        if not self.ignore_errors:
+            msg += ". Use --ignore-errors to download the rest anyway"
+
+        raise AudibleCliException(msg)
+
+
+async def consume(run: DownloadRun):
     while True:
         cmd, kwargs = await QUEUE.get()
         try:
+            # Never leave this loop on error. A consumer that dies stops
+            # taking items, and once every consumer is gone QUEUE.join()
+            # waits forever for jobs nobody will pick up.
+            if run.abort.is_set():
+                run.skipped += 1
+                continue
+
             await cmd(**kwargs)
         except Exception as e:
             logger.error(e)
-            if not ignore_errors:
-                raise
+            run.record(e)
         finally:
             QUEUE.task_done()
+
+
+async def drain_queue(run: DownloadRun, sim_jobs: int):
+    """Work off QUEUE with `sim_jobs` consumers until it is empty."""
+    consumers = [
+        asyncio.create_task(consume(run)) for _ in range(sim_jobs)
+    ]
+    joiner = asyncio.create_task(QUEUE.join())
+    try:
+        # A consumer only ever finishes by dying. Waiting on them next to the
+        # join means such a death surfaces here, instead of leaving
+        # QUEUE.join() waiting for items that nobody will pick up anymore.
+        await asyncio.wait(
+            [joiner, *consumers], return_when=asyncio.FIRST_COMPLETED
+        )
+        if not joiner.done():
+            # A consumer ended while jobs were still queued. Surface why, so
+            # the run does not look like it merely finished early.
+            for consumer in consumers:
+                if consumer.done() and not consumer.cancelled():
+                    exc = consumer.exception()
+                    if exc is not None:
+                        raise exc
+
+            raise AudibleCliException(
+                "A download worker stopped unexpectedly, the remaining jobs "
+                "were not processed"
+            )
+    finally:
+        # the consumer is still awaiting an item, cancel it
+        joiner.cancel()
+        for consumer in consumers:
+            consumer.cancel()
+
+        await asyncio.gather(joiner, *consumers, return_exceptions=True)
+        display_counter()
 
 
 def queue_job(
@@ -729,7 +801,7 @@ def display_counter():
 )
 @click.option(
     "--jobs", "-j",
-    type=int,
+    type=click.IntRange(min=1),
     default=3,
     show_default=True,
     help="number of simultaneous downloads"
@@ -973,16 +1045,6 @@ async def cli(session, api_client, **params):
             )
 
     # schedule the consumer
-    consumers = [
-        asyncio.create_task(consume(ignore_errors)) for _ in range(sim_jobs)
-    ]
-    try:
-        # wait until the consumer has processed all items
-        await QUEUE.join()
-    finally:
-        # the consumer is still awaiting an item, cancel it
-        for consumer in consumers:
-            consumer.cancel()
-
-        await asyncio.gather(*consumers, return_exceptions=True)
-        display_counter()
+    run = DownloadRun(ignore_errors)
+    await drain_queue(run, sim_jobs)
+    run.raise_for_errors()


### PR DESCRIPTION
Closes #235, closes #239. Takes a first step on #256 — see the caveat below.

## The bug

`consume()` re-raised on error when `--ignore-errors` was not given:

```python
except Exception as e:
    logger.error(e)
    if not ignore_errors:
        raise          # leaves the `while True` loop
finally:
    QUEUE.task_done()
```

That does not just abort the job, it kills the consumer task. `task_done()` still ran for the current item, but the consumer never took another one. Once every `--jobs` consumer had died this way, `await QUEUE.join()` waited forever for items nobody would pick up.

Reproduced against the real `consume()`/`QUEUE`:

| Scenario | Before |
| --- | --- |
| `-j 3`, 3 failures first, then 5 good jobs | **hangs**, 5 items stranded |
| `-j 1`, 1 failure, then 2 good jobs | **hangs** |
| `-j 3`, 1 failure | completes — two consumers survive |
| `--ignore-errors` | completes — nothing re-raises |

The default is `-j 3`, so three early failures were enough. That matches #235 ("a lot of Skip download and then suddenly audible hangs") and its offshoot #239.

The failure was invisible too: the exception sat in a dead task, and the `asyncio.gather(..., return_exceptions=True)` that would have collected it only runs after `QUEUE.join()` returns — which in this state never happens.

## The fix

`DownloadRun` holds the abort event, the collected errors and the skipped count, shared by all consumers. The consumer never leaves its loop: on failure it records the error, and if `--ignore-errors` is not set it sets the abort event. Consumers then stop starting jobs and only acknowledge what is left, so `QUEUE.join()` can return. Downloads already in flight finish rather than being cancelled mid-write.

Waiting on `QUEUE.join()` alone was the deeper flaw — *any* consumer ending early strands the queue. `drain_queue()` now waits on the join and the consumers together, so a worker that dies for any reason is reported instead of hanging the run. `--jobs` also rejects values below `1`; `-j 0` previously queued work that no consumer would ever pick up.

This also makes `--ignore-errors` mean what its help text says. Before, its absence aborted nothing: one consumer died while the others kept downloading until they died too.

## Exit code

A run in which a job raised now ends in `AudibleCliException`, which `cli.main()` maps to exit code 2 — with `--ignore-errors` as well.

⚠️ **#256 is only partially addressed here.** Failures that are only logged never reach `DownloadRun` and still exit zero: an unknown ASIN or title, a cover with no URL, and downloads that return a non-success `Status` (`DownloadError`, `DownloadErrorStatusCode`, `DownloadSizeMismatch`, `DownloadContentTypeMismatch`). Capturing those means threading the run state through every download function and separating real failures from legitimate `DestinationAlreadyExists` skips — worth its own PR, so #256 stays open. The changelog entry is worded to match what actually holds.

## Relation to #257

#257 also targets #256 and overlaps in `consume()`, error tracking and the command epilogue, so the two should not be merged independently. It keeps the re-raise and therefore the deadlock, and its `return 1` from the Click callback does not become the process exit status — Click discards callback return values in standalone mode. Its useful part is the additional error capture points, which are exactly what the #256 follow-up needs.

## Verification

A harness driving the real `consume()`/`QUEUE`/`drain_queue()` — not a reimplementation:

* all three previously hanging scenarios now drain completely
* first failure stops the 20 queued jobs behind it; two slow in-flight jobs still run to completion
* `--ignore-errors` runs everything and only counts the failures
* an error-free run is unchanged and raises nothing
* a consumer dying for an unrelated reason is reported rather than hanging
* `-j 0` and `-j -1` are rejected by Click
* `AudibleCliException` → exit 2 and `RuntimeError` → exit 3 confirmed through `cli.main()`

`ruff check src plugin_cmds` shows no new findings; `cli`'s pre-existing C901 complexity drops from 32 to 31 because the draining moved out of it.

No tests were committed — the repo still has no pytest dependency and no CI job to run them. That gap is tracked separately.
