### PR TITLE
ci: name releases after the tag, not the full ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: Release ${{ github.ref }}
+        name: Release ${{ github.ref_name }}
         draft: false
         prerelease: false
 


### PR DESCRIPTION
Every release is created as **"Release refs/tags/vX.Y.Z"** and the title has to be corrected by hand afterwards.

`github.ref` expands to the full ref on a tag push — `refs/tags/v0.5.0`. `github.ref_name` holds just `v0.5.0`, which is exactly the form every published release has been renamed to:

```
Release v0.5.0
Release v0.4.0
Release v0.3.3
Release v0.3.2
```

One-line change in `.github/workflows/build.yml`; the workflow still parses and its trigger is untouched.

The release body is a separate matter — `softprops/action-gh-release` is called without `body`, so the notes are still written manually after each release. Wiring that to the matching `CHANGELOG.md` section would remove the last manual step, but that is a bigger change and not part of this PR.
