### PR TITLE
fix: accept a str filename in build_auth_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- `build_auth_file()` no longer raises an `AttributeError` when its `filename` is passed as a `str`, which its signature allows. The failure happened after the login had already registered the device, so the registration was lost without the auth file being written
+
 ## [0.5.0] - 2026-08-05
 
 ### Breaking

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -143,7 +143,10 @@ def build_auth_file(
     echo()
     secho("Login with amazon to your audible account now.", bold=True)
 
-    file_options = {"filename": pathlib.Path(filename)}
+    # Normalize once: the signature allows a str, but the parent directory is
+    # created further down, after the login has already registered the device
+    filename = pathlib.Path(filename)
+    file_options = {"filename": filename}
     if file_password:
         file_options.update(
             password=file_password,


### PR DESCRIPTION
`build_auth_file()` declares `filename: Union[str, pathlib.Path]`, but only the copy placed into `file_options` is converted:

```python
file_options = {"filename": pathlib.Path(filename)}   # converted copy
...
if not filename.parent.exists():                      # original value
    filename.parent.mkdir(parents=True)
```

A caller passing a `str` — which the signature explicitly allows — gets:

```
AttributeError: 'str' object has no attribute 'parent'
```

## Why this is worse than a plain type error

That access sits *after* `Authenticator.from_login()` has registered the device with Amazon and after the "Successfully registered" message is printed. The crash therefore lands between registering the device and writing the auth file, leaving a device registered on Amazon's side whose credentials were never saved.

## Fix

Normalize once at the top and use that value everywhere.

## Scope

Latent, not live: both callers in the code base pass a `Path` today (`cmd_manage.py:184`, `cmd_quickstart.py:162`). The function is public API though, and the signature invites the `str` that breaks it.

## Verification

Reproduced with the `Authenticator` stubbed out, so no real login is involved:

```
before:  pathlib.Path -> ok      str -> AttributeError: 'str' object has no attribute 'parent'
after:   pathlib.Path -> ok      str -> ok
```

`ruff check src plugin_cmds` shows no new findings.
