### PR TITLE
ci: move all actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Create Release
       id: create-release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -79,22 +79,22 @@ jobs:
             OUT_FILE_NAME: audible_win.zip
             ASSET_MIME: application/zip
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Build with pyinstaller for ${{matrix.TARGET}}
       run: ${{matrix.CMD_BUILD}}
 
     - name: Upload Release Asset
       id: upload-release-asset
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/pypi-publish-test.yml
+++ b/.github/workflows/pypi-publish-test.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Build package
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Build package
         run: |

--- a/.github/workflows/uv-lock-maintenance.yml
+++ b/.github/workflows/uv-lock-maintenance.yml
@@ -11,20 +11,28 @@ permissions:
 
 jobs:
   lock:
+    # Fork pull requests, Dependabot included, get no repository secrets and
+    # only a read-only token, and their head branch does not exist here. Skip
+    # them instead of failing the checkout below.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GH_PAT }}
+          # On pull_request, checkout defaults to the detached merge commit.
+          # git-auto-commit-action needs the actual branch to commit onto, and
+          # errors out on a detached HEAD since v6.
+          ref: ${{ github.head_ref }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
       - name: "Run uv lock command"
         run: uv lock
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         id: auto-commit-action
         with:
           commit_message: Regenerate uv.lock


### PR DESCRIPTION
Every workflow run is annotated with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`, `astral-sh/setup-uv@v6`, `softprops/action-gh-release@v2`.

## The bump

I checked `action.yml` for every version to find where each action actually switched runtimes, rather than trusting the changelogs:

| Action | before | after | Node 24 since |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | v5 |
| `actions/setup-python` | v5 | **v7** | v6 |
| `astral-sh/setup-uv` | v6 | **v9.0.0** | v7 |
| `softprops/action-gh-release` | v2 | **v3** | v3 |
| `stefanzweifel/git-auto-commit-action` | v5 | **v7** | v7 |

`setup-uv` is pinned to a full version on purpose: it stopped publishing major and minor tags with v8 as a supply-chain measure. `astral-sh/setup-uv@v9` **does not resolve** — only `v9.0.0` exists — and using it would abort the job with "unable to resolve action".

`git-auto-commit-action` was not in the warning because the lock workflow only runs on pull requests touching `pyproject.toml`, so it was absent from the release run.

## Breaking changes that reach these workflows

**`git-auto-commit-action` refuses to run on a detached HEAD.** The check arrived in v6.0.0, was disabled again in v6.0.1, and is back in v7. The lock workflow runs on `pull_request`, where checkout defaults to the detached merge commit — the run log confirms `You are in 'detached HEAD' state`. The action would now fail where it previously did nothing. It has in fact never committed anything: all recorded runs end in `Working tree clean. Nothing to commit.`, so the problem was latent.

Fixed by checking out `github.head_ref`, plus a job guard for fork pull requests. Forks — Dependabot included — get no repository secrets, so `GH_PAT` would be empty, and their head branch does not exist in this repository, so the checkout itself would fail. They are now skipped instead.

**`setup-uv` v9 changes the `prune-cache` default to `false`.** This affects all four workflows, not only the one setting `enable-cache` explicitly, because `enable-cache` defaults to `auto` and is enabled on GitHub-hosted runners. Expect larger caches; a cost and quota matter, not a build failure.

## Breaking changes that do not apply

`setup-python` v7 removes the `pip-install` input, `setup-uv` v7 removes `server-url` and v8 removes the old `manifest-file` format, `checkout` v7 blocks fork checkouts for `pull_request_target` and `workflow_run`, and `action-gh-release` v3 is a pure runtime bump with unchanged inputs and outputs. None of those inputs or triggers are used here. `changes_detected`, the only output consumed anywhere, still exists in `git-auto-commit-action@v7`.

`checkout` v6 moves persisted credentials into `$RUNNER_TEMP` instead of the workspace, wired up through git config. Later `git push` calls stay authenticated, so `git-auto-commit-action` is unaffected — it is a Node action running git on the host, not an isolated container.

## Supersedes

#244, #245, #246 and #250 — the four open Dependabot PRs — are all covered here, and each targeted a version that is itself already behind. Worth closing them as superseded after merging rather than waiting for Dependabot: their age suggests updates may be paused, which would also explain why `softprops/action-gh-release` never got a PR at all despite v3 being available.

## Noticed, deliberately left out

* `.github/dependabot.yml` uses `dependency-type: development` for the `github-actions` ecosystem, which only supports it for Bundler, Composer, Mix, Maven, npm and pip. That is why action updates arrive as separate PRs instead of the configured group.
* `build.yml` does not declare `permissions: contents: write`, which `action-gh-release` requires. It works today only because of the repository-wide default token permission.
* The release is created with `draft: false` *before* the six build jobs run, so a matrix failure leaves an incomplete public release behind.
* `pypi-publish.yml` is named "publish to TestPyPI" but publishes to real PyPI; `pypi-publish-test.yml` uses the deprecated `repository_url` alias instead of `repository-url`.
* Both publish workflows use long-lived API tokens; PyPI recommends Trusted Publishing over OIDC.
* `uv run` in the build matrix has no `--locked`/`--frozen`, so a stale lockfile would be silently updated on the release runner.
* The lock workflow has no `concurrency` group and commits unsigned.
* No workflow runs pytest or Ruff, although both are configured and `tests/test_cmd_manage.py` now exists.

The release title (`Release refs/tags/vX.Y.Z`) is already handled in #272.
