### PR TITLE
ci: skip the lock workflow for Dependabot pull requests

### DIFF
--- a/.github/workflows/uv-lock-maintenance.yml
+++ b/.github/workflows/uv-lock-maintenance.yml
@@ -11,10 +11,13 @@ permissions:
 
 jobs:
   lock:
-    # Fork pull requests, Dependabot included, get no repository secrets and
-    # only a read-only token, and their head branch does not exist here. Skip
-    # them instead of failing the checkout below.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # This job commits with GH_PAT, so it only works where that secret and a
+    # branch to push to both exist. Fork pull requests have neither. Dependabot
+    # branches do live here, but Dependabot-triggered runs read their secrets
+    # from a separate store, so GH_PAT would be empty — hence the second check.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Fixes the guard I added in #274, which did not do what its comment claimed.

## The problem

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

The comment said "Fork pull requests, **Dependabot included**". The condition does not achieve that: Dependabot's branches live in this repository, so they pass the check. Dependabot-triggered runs read their secrets from a separate store, so the Actions secret `GH_PAT` resolves to an empty string and the push cannot succeed.

Reachable in practice — the workflow triggers on `pull_request` touching `pyproject.toml`, which is exactly what a Dependabot dependency update changes.

## The fix

Check the actor as well, and describe what the condition actually guarantees:

| Context | Head branch here? | `GH_PAT` available? | Result |
| --- | --- | --- | --- |
| Own branch, human | yes | yes | runs |
| Dependabot | yes | no | skipped |
| Fork PR | no | no | skipped |
| Other bot, own branch | yes | yes | runs |

`github.actor` is the right field: GitHub documents the Dependabot restrictions in terms of it, and it keeps naming the bot on a human re-run, which is correct since re-runs keep the original actor's privileges. `github.triggering_actor` would flip to the human and wrongly let the job through.

## Not included

A read-only `uv lock --check` for the skipped cases would be better than skipping outright — nothing else checks the lockfile on pull requests, so a stale `uv.lock` can still be merged unnoticed. That needs a separate checkout without `GH_PAT` and new status semantics, so it belongs in its own PR.
