### PR TITLE
ci: harden the release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+# Required by action-gh-release to create, upload to and publish the release
+permissions:
+  contents: write
+
 env:
   PYTHON_VERSION: "3.14"
 
@@ -13,14 +17,16 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-    - name: Create Release
+    - name: Create draft release
       id: create-release
       uses: softprops/action-gh-release@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: Release ${{ github.ref_name }}
-        draft: false
+        # Keep it a draft until every build has attached its asset. Updating
+        # an existing release keeps the draft state it already has, so this
+        # covers a new release and one that is still a draft, but not a tag
+        # that was published before.
+        draft: true
         prerelease: false
 
   build:
@@ -33,51 +39,45 @@ jobs:
           - os: ubuntu-latest
             TARGET: linux
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 zip -r9 audible_linux_ubuntu_latest audible
             OUT_FILE_NAME: audible_linux_ubuntu_latest.zip
-            ASSET_MIME: application/zip  # application/octet-stream
           - os: ubuntu-22.04
             TARGET: linux
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 zip -r9 audible_linux_ubuntu_22_04 audible
             OUT_FILE_NAME: audible_linux_ubuntu_22_04.zip
-            ASSET_MIME: application/zip  # application/octet-stream
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 zip -r9 audible_mac audible
             OUT_FILE_NAME: audible_mac.zip
-            ASSET_MIME: application/zip
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 zip -r9 audible_mac_dir audible
             OUT_FILE_NAME: audible_mac_dir.zip
-            ASSET_MIME: application/zip 
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 powershell Compress-Archive audible audible_win_dir.zip
             OUT_FILE_NAME: audible_win_dir.zip
-            ASSET_MIME: application/zip
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
-                uv run --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
                 powershell Compress-Archive audible.exe audible_win.zip
             OUT_FILE_NAME: audible_win.zip
-            ASSET_MIME: application/zip
     steps:
     - uses: actions/checkout@v7
 
@@ -95,7 +95,25 @@ jobs:
     - name: Upload Release Asset
       id: upload-release-asset
       uses: softprops/action-gh-release@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         files: ./dist/${{ matrix.OUT_FILE_NAME}}
+        # Without this the first upload would publish the draft
+        draft: true
+        fail_on_unmatched_files: true
+        # An asset of the same name is skipped rather than replaced, missing
+        # ones are still uploaded. Keeps a rerun on an already published tag
+        # from swapping good assets for ones no build step has verified.
+        overwrite_files: false
+
+  publish_release:
+    name: Publish Release
+    # Only reached when all six builds succeeded, so a failed matrix leaves
+    # the draft behind instead of a public release with missing assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish the draft release
+      uses: softprops/action-gh-release@v3
+      with:
+        # Name and body are kept from the draft when not passed again
+        draft: false


### PR DESCRIPTION
Six changes to `build.yml`, all around one risk: the release goes public before anything has been verified.

## Draft first

`action-gh-release` always creates a release as a draft and publishes it in a separate finalize step, which it skips while `draft: true` is set. So the release is now built as a draft and only released once all six builds have attached their asset:

| Job | | |
| --- | --- | --- |
| `create_release` | `draft: true` | creates the draft |
| `build` (6× matrix) | `draft: true` | attaches assets, stays a draft |
| `publish_release` | `draft: false`, `needs: build` | finalizes it |

Without `draft: true` on the **upload** step the first successful matrix job would have published the incomplete release — that step previously passed no `draft` at all.

`publish_release` carries no `if:`, so a failed or cancelled build skips it and leaves the draft behind, with whatever assets made it, for inspection or a rerun. Name and body survive: on update the action falls back to the existing release's values when the inputs are absent (`const name = config.input_name || existingRelease.name || tag`).

## The guarantees behind it

`fail_on_unmatched_files: true` — defaults to false, so a renamed or missing artifact would have left the matrix job green and published a release without that asset.

`overwrite_files: false` — the draft guarantee covers a new release or one that is still a draft, but **not** a tag that was published before: updating an existing release keeps the draft state it already has. Re-running the workflow for a published tag therefore uploads straight to the public release, and `fail_on_unmatched_files` only proves a file exists, not that it is any good. With overwriting off, an asset of the same name is skipped instead of replaced, so a rerun still fills in missing assets but never swaps a good one for an unverified build.

## The rest

`permissions: contents: write` — required by `action-gh-release`; the workflow only worked because of the repository-wide default token permission. A switch to a read-only default would have broken releases with a 403.

`uv run --locked` in all six build commands — without it a stale lockfile is silently updated on the runner and the published binaries no longer match what is committed. `--frozen` would use the lockfile without checking it against `pyproject.toml`, which is not what a release needs.

The deprecated `GITHUB_TOKEN` env blocks are gone — the `token` input already defaults to `github.token` — and the six `ASSET_MIME` matrix fields with them, unreferenced since the switch to `action-gh-release`, which derives the MIME type from the file name itself.

## Verification

This workflow cannot be exercised without pushing a tag and publishing a real release, so the draft mechanics were verified against the action's source at `v3.0.2` instead:

* creating always yields a draft — `const draft = prerelease === true ? config.input_draft === true : true`
* updating never changes it — `draft: existingRelease.draft`
* publishing happens only in `finalizeRelease`, which returns early on `input_draft === true`
* `overwrite_files: false` skips an existing asset (`return null`) rather than failing, which is what keeps the rerun path working

`strategy.fail-fast` is left at its default. With draft-first, an early cancel changes nothing about what gets published.

## Known gap

Nothing here pins the uv version. `setup-uv@v9.0.0` pins the action, while `required-version = ">=0.7.6"` lets it install the newest uv, and lockfile compatibility is only guaranteed within a minor version. `--locked` could therefore fail on a release build even though the lockfile is fine for the uv that produced it — a loud failure rather than a silent mismatch, but worth knowing.
