### PR TITLE
ci: drop unsupported and dead Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -8,32 +7,10 @@ updates:
     groups:
       github-actions-updates:
         applies-to: version-updates
-        dependency-type: development
+        patterns: ["*"]
       github-actions-security-updates:
         applies-to: security-updates
-        dependency-type: development
-  - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-    groups:
-      workflow-updates:
-        applies-to: version-updates
-        dependency-type: development
-      workflow-security-updates:
-        applies-to: security-updates
-        dependency-type: development
-  - package-ecosystem: pip
-    directory: "/docs"
-    schedule:
-      interval: weekly
-    groups:
-      doc-updates:
-        applies-to: version-updates
-        dependency-type: development
-      doc-security-updates:
-        applies-to: security-updates
-        dependency-type: production
+        patterns: ["*"]
   - package-ecosystem: uv
     directory: "/"
     schedule:
@@ -42,9 +19,9 @@ updates:
     allow:
       - dependency-type: "all"
     groups:
-      pip-version-updates:
+      uv-version-updates:
         applies-to: version-updates
-        dependency-type: development
-      pip-security-updates:
+        patterns: ["*"]
+      uv-security-updates:
         applies-to: security-updates
-        dependency-type: production
+        patterns: ["*"]


### PR DESCRIPTION
Three problems, all of which made the file describe something Dependabot never did.

## `dependency-type` in groups is unsupported here

Both the `github-actions` and the `uv` groups filtered on `dependency-type: development`. GitHub's [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#dependency-type-groups) lists that sub-option as **"Supported by: `bundler`, `composer`, `mix`, `maven`, `npm`, and `pip`"** — neither of the two ecosystems used here.

That is the visible symptom you can check against the repository history: action updates kept arriving as four separate pull requests (#244, #245, #246, #250) instead of the configured group. Replaced with `patterns: ["*"]`, the documented all-match rule.

## Two pip entries pointed at nothing

`pip` was configured for `/.github/workflows` and for `/docs`. Neither holds a manifest — no `requirements*.txt`, `pyproject.toml`, `setup.py` or `Pipfile` in either. They could never produce an update. Sphinx is not a Dependabot ecosystem, and the root `uv` entry already covers the project's dependencies.

## `enable-beta-ecosystems` is obsolete

The same reference marks it **"Not currently in use"**. Worth checking before removing, since it would matter if `uv` were still a beta ecosystem — it is not; the reference lists it alongside the regular ones.

## Also

The two `uv` groups were still named `pip-*` from before the switch to uv. Renamed to match their ecosystem. No grouped pull request is currently open that this could disturb — the two still-open Dependabot PRs are single action bumps.

`allow: - dependency-type: "all"` on the `uv` entry stays: that is the `allow` option, not the group filter, and it is valid for uv.
