### PR TITLE
fix: make the convert-oa-file plugin work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `build_auth_file()` no longer raises an `AttributeError` when its `filename` is passed as a `str`, which its signature allows. The failure happened after the login had already registered the device, so the registration was lost without the auth file being written
+- The `convert-oa-file` plugin works again. It has failed to even load since v0.2 because it imported `pass_session` from the wrong module, and behind that sat a tuple passed to `pathlib.Path()`, a call to a `Session` method that does not exist, an expiry read as seconds although OpenAudible writes milliseconds, a `KeyError` on cookie fields that are optional, and a profile name from the converted file that could write outside the config directory
 
 ## [0.5.0] - 2026-08-05
 

--- a/plugin_cmds/convert_oa_cred.py
+++ b/plugin_cmds/convert_oa_cred.py
@@ -7,11 +7,14 @@ audible-cli.
 
 import json
 import pathlib
+import re
 
 import audible
 import click
+from click import echo
 
-from audible_cli.config import pass_session
+from audible_cli.decorators import pass_session
+from audible_cli.exceptions import AudibleCliException
 
 
 def extract_data_from_file(credentials):
@@ -28,21 +31,67 @@ def extract_data_from_file(credentials):
     return origins
 
 
-def make_auth_file(fn, origin):
+# A POSIX timestamp this large is year 5138 in seconds but a plausible date
+# in milliseconds, which is what OpenAudible writes. No Audible credential
+# expires that far out, so treat anything above it as milliseconds.
+MILLISECOND_THRESHOLD = 1e11
+
+# Anything outside this is refused rather than sanitized, which keeps the
+# check from having to know every way a name can mean something other than a
+# file — Windows device aliases like `CONOUT$`, alternate data streams, path
+# separators of either platform and unicode lookalikes all fail it already.
+USABLE_PROFILE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z", re.ASCII)
+
+# Still reserved on Windows even though they pass the pattern above, with or
+# without an extension
+WINDOWS_DEVICE_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
+
+
+def normalize_expires(expires):
+    """Return `expires` in seconds.
+
+    audible stores this as a POSIX timestamp in seconds and hands it to
+    `datetime.fromtimestamp`, which rejects a millisecond value outright.
+    """
+    if expires is not None and abs(expires) > MILLISECOND_THRESHOLD:
+        return expires / 1000
+    return expires
+
+
+def is_usable_profile_name(name):
+    """Whether `name` can become a file directly below the app dir.
+
+    The name comes out of the file being converted, so it is accepted only
+    when it matches a deliberately narrow pattern. Refusing everything else
+    is what makes this safe: a list of things to reject would have to keep up
+    with every way a name can mean something other than a plain file.
+    """
+    if not USABLE_PROFILE_NAME.match(name):
+        return False
+
+    return name.split(".")[0].upper() not in WINDOWS_DEVICE_NAMES
+
+
+def make_auth_file(origin):
     tokens = origin["tokens"]
     adp_token = tokens["mac_dms"]["adp_token"]
     device_private_key = tokens["mac_dms"]["device_private_key"]
-    store_authentication_cookie = tokens["store_authentication_cookie"]
+    # Both cookie fields are optional in audible's own registration handling
+    store_authentication_cookie = tokens.get("store_authentication_cookie")
     access_token = tokens["bearer"]["access_token"]
     refresh_token = tokens["bearer"]["refresh_token"]
-    expires = origin["additionnel"]["expires"]
+    expires = normalize_expires(origin["additionnel"]["expires"])
 
     extensions = origin["extensions"]
     device_info = extensions["device_info"]
     customer_info = extensions["customer_info"]
 
     website_cookies = {}
-    for cookie in tokens["website_cookies"]:
+    for cookie in tokens.get("website_cookies") or []:
         website_cookies[cookie["Name"]] = cookie["Value"].replace(r'"', r"")
 
     data = {
@@ -64,23 +113,30 @@ def make_auth_file(fn, origin):
 
 @click.command("convert-oa-file")
 @click.option(
-    "--input", "-i",
-    type=click.Path(exists=True, file_okay=True),
+    "--input", "-i", "input_files",
+    type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
     multiple=True,
-    help="OpenAudible credentials.json file")
+    required=True,
+    help="OpenAudible credentials.json file. Can be given more than once.")
 @pass_session
-def cli(session, input):
+def cli(session, input_files):
     """Converts a OpenAudible credential file to a audible-cli auth file.
 
     Stores the auth files in app dir
     """
-    fdata = pathlib.Path(input).read_text("utf-8")
-    fdata = json.loads(fdata)
+    app_dir = session.app_dir
 
-    x = extract_data_from_file(fdata)
-    for k, v in x.items():
-        app_dir = pathlib.Path(session.get_app_dir())
-        fn = app_dir / pathlib.Path(k).with_suffix(".json")
-        auth = make_auth_file(fn, v)
-        auth.to_file(fn)
+    for input_file in input_files:
+        credentials = json.loads(input_file.read_text("utf-8"))
+
+        for name, origin in extract_data_from_file(credentials).items():
+            if not is_usable_profile_name(name):
+                raise AudibleCliException(
+                    f"{input_file}: {name!r} is not a usable profile name"
+                )
+
+            target = app_dir / pathlib.Path(name).with_suffix(".json")
+            auth = make_auth_file(origin)
+            auth.to_file(target)
+            echo(f"Wrote {click.format_filename(target)}")
 


### PR DESCRIPTION
The `convert-oa-file` plugin has been dead since **v0.2**. It imports `pass_session` from `audible_cli.config`, but that moved to `audible_cli.decorators` back then, so loading the module raises `ImportError` and the command never registers. The file has not been touched functionally since v0.1.0, which is why nobody noticed.

It surfaced from an `A002` lint finding — "argument `input` shadows a builtin" — on exactly the line that also passes a tuple to `pathlib.Path()`.

## Six faults, each fatal on its own

| | |
| --- | --- |
| `ImportError` | `pass_session` imported from `config` instead of `decorators` |
| `TypeError` | `--input` is `multiple=True`, so click hands over a tuple, passed straight to `pathlib.Path()` |
| `AttributeError` | `session.get_app_dir()` does not exist; `Session` exposes `app_dir` as a property |
| `ValueError` | `expires` arrives in milliseconds, and audible hands it to `datetime.fromtimestamp` |
| path traversal | the profile name comes out of the converted file and becomes a filename |
| `KeyError` | two cookie fields are optional, but were indexed directly |

The last three would only have hit on the first real conversion, after the first three were fixed.

## `expires`

A real OpenAudible file carries `1614461913439`. That is 13 digits, and `datetime.fromtimestamp` answers with `ValueError: year must be in 1..9999, not 53130`. Converted it is 2021-02-27, which matches the access token cookies in the same file — they expire a day later.

The conversion only applies above a threshold where the seconds reading would be year 5138, so a file that already stores seconds passes through untouched. That is a plausibility assumption about credential lifetimes, not a proof, and the comment says so.

## The profile name

Each key of the credentials file becomes a filename directly below the config directory:

```
'../../tmp/x' -> ~/.audible/../../tmp/x.json
'/etc/x'      -> /etc/x.json          # app_dir discarded entirely
```

Names are now matched against a narrow pattern rather than checked for known-bad shapes:

```python
USABLE_PROFILE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z", re.ASCII)
```

Refusing everything else is what makes it hold: separators of either platform, alternate data stream syntax, the empty string and unicode lookalikes all fail without the check having to enumerate them. The Windows device names that still pass the pattern — `CON`, `NUL`, `COM1` — are rejected on top.

## Verified

Against the real OpenAudible structure, with the secrets replaced and never written to disk:

* real file → `rc=0`, auth file written, `expires` → 2021-02-27, locale `de`, cookies correctly unquoted, `active_device` skipped
* without the optional cookie fields → `rc=0`
* `../../tmp/x`, `/etc/x`, `""`, `NUL`, `CONOUT$`, `COM¹` → `rc=1`, nothing written anywhere
* missing `-i`, a directory, a nonexistent file → `rc=2` with a proper click message

The name check was exercised against 24 inputs, including the three that must stay allowed: a device serial, `console` (contains `CON`) and `profil_2.alt`.

## Left alone

Weak handling of malformed JSON, and partial state when a later input file fails after earlier ones were written — both are usability, not defects, and would inflate a bugfix. The `D205` in this file belongs to the lint cleanup batch.
