### PR TITLE
style: clear the harmless Ruff findings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ import audible_cli
 # -- Project information -----------------------------------------------------
 
 project = "audible-cli"
-copyright = "2020, mkb79"
+project_copyright = "2020, mkb79"
 author = "mkb79"
 
 # The full version, including alpha/beta/rc tags

--- a/plugin_cmds/convert_oa_cred.py
+++ b/plugin_cmds/convert_oa_cred.py
@@ -1,7 +1,8 @@
-"""Converts the credentials.json file from OpenAudible >= v2.4 beta to an
-audible-cli auth file. The credentials.json file from OpenAudible leaves
-unchanged, so you can use one device registration for OpenAudible and
-audible-cli.
+"""Convert an OpenAudible credentials.json file to an audible-cli auth file.
+
+Supports OpenAudible >= v2.4 beta. The credentials.json file from
+OpenAudible is left unchanged, so you can use one device registration for
+OpenAudible and audible-cli.
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,20 +194,15 @@ lines-after-imports = 2
 # does not, because per-file-ignores keys on file and rule rather than on
 # individual findings. Shrink the list by fixing a rule in a file and
 # dropping its code here.
-"docs/source/conf.py" = ["A001"]
 "plugin_cmds/cmd_decrypt.py" = ["PLR0917"]
-"plugin_cmds/convert_oa_cred.py" = ["A002", "D205"]
-"src/audible_cli/_logging.py" = ["D205"]
-"src/audible_cli/cmds/__init__.py" = ["D205"]
 "src/audible_cli/cmds/cmd_download.py" = ["ASYNC240", "C901", "PLR0917", "PLW0603", "PLW2901", "S101"]
 "src/audible_cli/cmds/cmd_manage.py" = ["PLR0917"]
-"src/audible_cli/config.py" = ["B904", "D417"]
-"src/audible_cli/decorators.py" = ["B904", "D205", "RUF001"]
+"src/audible_cli/config.py" = ["B904"]
+"src/audible_cli/decorators.py" = ["B904"]
 "src/audible_cli/downloader.py" = ["PLR0917"]
-"src/audible_cli/models.py" = ["B904", "D205", "S101"]
-"src/audible_cli/plugins.py" = ["D205"]
-"src/audible_cli/utils.py" = ["PGH004", "PLR0917"]
-"utils/update_chapter_titles.py" = ["D205", "S101"]
+"src/audible_cli/models.py" = ["B904", "S101"]
+"src/audible_cli/utils.py" = ["PLR0917"]
+"utils/update_chapter_titles.py" = ["S101"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/audible_cli/_logging.py
+++ b/src/audible_cli/_logging.py
@@ -137,8 +137,10 @@ def _normalize_echo_kwargs(echo_kwargs):
 
 
 def click_basic_config(logger=None, style_kwargs=None, echo_kwargs=None):
-    """Set up the default handler (:py:class:`ClickHandler`) and formatter
-    (:py:class:`ColorFormatter`) on the given logger.
+    """Set up the default handler and formatter on the given logger.
+
+    The handler is :py:class:`ClickHandler`, the formatter
+    :py:class:`ColorFormatter`.
     """
     logger = _normalize_logger(logger)
     style_kwargs = _normalize_style_kwargs(style_kwargs)

--- a/src/audible_cli/cmds/__init__.py
+++ b/src/audible_cli/cmds/__init__.py
@@ -23,8 +23,7 @@ cli_cmds = [
 
 
 def build_in_cmds(func=None):
-    """A decorator to register build-in CLI commands to an instance of
-    `click.Group()`.
+    """Decorate a `click.Group()` to register the built-in CLI commands.
 
     Returns:
     -------

--- a/src/audible_cli/config.py
+++ b/src/audible_cli/config.py
@@ -153,6 +153,8 @@ class ConfigFile:
             is_primary: If ``True``, this profile is set as primary in the
                 ``APP`` section
             write_config: If ``True``, save the config to file
+            **additional_options: Further key-value pairs stored verbatim in
+                the profile section
         """
         if self.has_profile(name):
             raise ProfileAlreadyExists(name)

--- a/src/audible_cli/decorators.py
+++ b/src/audible_cli/decorators.py
@@ -148,10 +148,10 @@ def password_option(func=None, **kwargs):
 
 
 def verbosity_option(func=None, *, cli_logger=None, **kwargs):
-    """A decorator that adds a `--verbosity, -v` option to the decorated
-    command.
-    Keyword arguments are passed to
-    the underlying ``click.option`` decorator.
+    """Add a `--verbosity, -v` option to the decorated command.
+
+    Keyword arguments are passed to the underlying ``click.option``
+    decorator.
     """
     def callback(ctx, param, value):
         x = getattr(logging, value.upper(), None)
@@ -227,7 +227,7 @@ def page_size_option(
     kwargs.setdefault(
         "help",
         (
-            "Number of items to request per API call (10–1000). Larger values "
+            "Number of items to request per API call (10-1000). Larger values "
             "reduce the number of requests but may cause timeouts or higher "
             "memory usage on slow connections. Tip: Use smaller values if you "
             "experience 408 timeouts or 429 rate limits."

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -173,8 +173,11 @@ class LibraryItem(BaseItem):
         return data.get("item", data)
 
     def _get_codec(self, quality: str):
-        """If quality is not ``best``, ensures the given quality is present in
-        them codecs list. Otherwise, will find the best aax quality available.
+        """Resolve the codec to download in.
+
+        If quality is not ``best``, ensures the given quality is present in
+        the codecs list. Otherwise, will find the best aax quality
+        available.
         """
         assert quality in ("best", "high", "normal",)
 

--- a/src/audible_cli/plugins.py
+++ b/src/audible_cli/plugins.py
@@ -1,5 +1,6 @@
-"""Core components for click_plugins
-https://github.com/click-contrib/click-plugins.
+"""Core components for click_plugins.
+
+See https://github.com/click-contrib/click-plugins.
 """
 import os
 import pathlib
@@ -11,8 +12,7 @@ import click
 
 
 def from_folder(plugin_dir: str | pathlib.Path):
-    """A decorator to register external CLI commands to an instance of
-    `click.Group()`.
+    """Decorate a `click.Group()` to register external CLI commands.
 
     Parameters
     ----------
@@ -60,8 +60,7 @@ def from_folder(plugin_dir: str | pathlib.Path):
 
 
 def from_entry_point(entry_point_group):
-    """A decorator to register external CLI commands to an instance of
-    `click.Group()`.
+    """Decorate a `click.Group()` to register external CLI commands.
 
     Parameters
     ----------
@@ -103,11 +102,13 @@ def from_entry_point(entry_point_group):
 
 
 class BrokenCommand(click.Command):
-    """Rather than completely crash the CLI when a broken plugin is loaded, this
-    class provides a modified help message informing the user that the plugin
-    is broken, and they should contact the owner. If the user executes the
-    plugin or specifies `--help` a traceback is reported showing the exception
-    the plugin loader encountered.
+    """Stand in for a plugin that failed to load.
+
+    Rather than completely crash the CLI when a broken plugin is loaded,
+    this class provides a modified help message informing the user that the
+    plugin is broken, and they should contact the owner. If the user
+    executes the plugin or specifies `--help` a traceback is reported
+    showing the exception the plugin loader encountered.
     """
 
     def __init__(self, name):

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -116,7 +116,7 @@ def prompt_external_callback(url: str) -> str:
     # import readline to prevent issues when input URL in
     # CLI prompt when using macOS
     try:
-        import readline  # noqa
+        import readline  # noqa: F401, PLC0415
     except ImportError:
         pass
 
@@ -271,7 +271,7 @@ class Downloader:
         if not 200 <= status_code < 400:
             try:
                 msg = self._tmp_file.read_text()
-            except:  # noqa
+            except Exception:
                 msg = "Unknown"
             logger.error("Error downloading %s. Message: %s", self._file, msg)
             return False
@@ -293,7 +293,7 @@ class Downloader:
             if content_type not in self._expected_content_type:
                 try:
                     msg = self._tmp_file.read_text()
-                except:  # noqa
+                except Exception:
                     msg = "Unknown"
                 logger.error(
                     "Error downloading %s. Wrong content type. Expected type(s): %s; "

--- a/utils/update_chapter_titles.py
+++ b/utils/update_chapter_titles.py
@@ -1,5 +1,6 @@
-"""This script replaces the chapter titles from a ffmetadata file with the one
-extracted from an API metadata/voucher file.
+"""Replace the chapter titles of an ffmetadata file.
+
+The replacements are taken from an API metadata/voucher file.
 
 Example:
 


### PR DESCRIPTION
Works off the Ruff baseline from #281, taking it from 42 findings to 26. Everything in here is a lint fix; what is left in the baseline needs a real code change.

| Rule | Change |
| --- | --- |
| `PGH004` ×3 | Blanket `# noqa` comments spelled out or removed |
| `D205` ×10 | Docstrings split into a summary line and a body |
| `D417` | `**additional_options` documented on `ConfigFile.add_profile` |
| `RUF001` | En dash in the `--page-size` help text is now a hyphen |
| `A001` | `docs/source/conf.py` uses Sphinx' `project_copyright` alias |
| `A002` | Already fixed by #286, entry dropped |

### The one behaviour change

Two of the three `PGH004` findings sat on bare `except:` clauses in `Downloader._postpare`, which read the error message off a failed download. A bare `except:` also swallows `KeyboardInterrupt`, so they now catch `Exception`. `except OSError` would be too narrow: the temp file holds a partial response body, so `read_text()` can just as well raise `UnicodeDecodeError`.

That class is still live — `cmd_download` uses it for covers and PDFs.

### On `A001`

This one looked like a permanent exception rather than debt, since `docs/source/conf.py` has to set the copyright. It is not: Sphinx has accepted `project_copyright` as an alias since 3.5, so the variable is simply renamed and the entry is gone. The repo pins no Sphinx version and carries no `.readthedocs.yaml`, so the docs build against a current release, and nothing else under `docs/` refers to the old name.

### Docstrings

`LibraryItem._get_codec` and `BrokenCommand` gained a summary line above their existing text. The rest were reworded around the split, mostly into the imperative mood the Google convention asks for. Where that rewording would have dropped the fact that the function is a decorator, the summary says so again.

Two typos Copilot spotted in docstrings this touches anyway, "them codecs list" and "build-in", are corrected. The `build_in_cmds` function keeps its name and so do the two occurrences in `plugin_cmds/README.md`; a rename is not a lint fix.

### What is left

The remaining 26 findings, in the order they are worth tackling: the error and input contracts (`B904`, `S101`), the download orchestration (`C901`, `PLW0603`, `PLW2901`, `ASYNC240`) and finally `PLR0917`.

### Verification

`ruff check`, `ruff format --check` and the 56 tests pass. The 42 → 26 count was measured by emptying the baseline block on both `master` and this branch and counting the findings it suppresses. No changelog entry, matching #282, #283 and #285.
