### PR TITLE
ci: say which index each publish workflow targets

### DIFF
--- a/.github/workflows/pypi-publish-test.yml
+++ b/.github/workflows/pypi-publish-test.yml
@@ -3,6 +3,9 @@ name: Upload Python Package to TestPyPI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.14"
 
@@ -10,7 +13,7 @@ jobs:
   build-n-publish:
     name: Build and publish Audible-cli to TestPyPI
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v7
 
@@ -26,8 +29,8 @@ jobs:
         run: |
           uv build
 
-      - name: Publish distribution to Test PyPI
+      - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,14 +1,17 @@
-name: Upload Python Package
+name: Upload Python Package to PyPI
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   PYTHON_VERSION: "3.14"
 
 jobs:
   build-n-publish:
-    name: Build and publish Audible-cli to TestPyPI
+    name: Build and publish Audible-cli to PyPI
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +33,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # Named even though it is the default, so that this workflow and
+          # the TestPyPI one state their target the same way
+          repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
`pypi-publish.yml` announced itself as publishing to TestPyPI — in the workflow name *and* the job name — while uploading to the real index with `PYPI_API_TOKEN`. Only the step name was right. Nothing was broken by it, but the run that publishes a release was the one that looked like a rehearsal.

### Changes

| File | Change |
| --- | --- |
| `pypi-publish.yml` | Workflow and job name say PyPI; target URL named explicitly |
| `pypi-publish-test.yml` | `repository_url` → `repository-url`; step name "Test PyPI" → "TestPyPI"; stray whitespace-only line |
| both | `permissions: contents: read` |

### Why the URL is now explicit

`pypi-publish.yml` set no repository at all and relied on a default. Checking `action.yml` of `pypa/gh-action-pypi-publish` showed where that default lives:

```yaml
repository-url:   # Canonical alias for `repository_url`
  required: false
  # no default
repository_url:   # DEPRECATED ALIAS; TODO: Remove in v3+
  deprecationMessage: >-
    The inputs have been normalized to use kebab-case.
    Use `repository-url` instead.
  default: https://upload.pypi.org/legacy/
```

So the index the production workflow uploaded to was decided by the default of an input marked for removal, which neither workflow mentioned. It is now written out.

The pair resolves as `repository-url: ${{ inputs.repository-url || inputs.repository_url }}`, so the canonical input wins and neither workflow changes where it uploads.

### Permissions

`contents: read` covers checkout, `uv build` and a token upload — the API token is what authorises the upload, not the workflow token. This matches `tests.yml` and `uv-lock-maintenance.yml`, which both declare permissions explicitly; `build.yml` needs `contents: write` because it creates releases.

`id-token: write` is deliberately not granted in advance. Trusted publishing would drop the API tokens altogether, but it needs that permission, removal of `password:` and configuration on PyPI, so it belongs in its own change.

### Deliberately left out

Both are worth a separate hardening PR:

- **SHA pinning.** No action reference is pinned to a full commit SHA, and `pypa/gh-action-pypi-publish@release/v1` is a moving tag that receives a PyPI token.
- **`environment:`.** Neither publish workflow uses a GitHub environment, so there is no required-reviewer gate on a production upload.

### Verification

Both files parse. `workflow_dispatch` remains the only trigger, so nothing here can fire on its own — the effect is visible only on the next manual publish.