### PR TITLE
refactor: make the error and input contracts explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,14 +195,10 @@ lines-after-imports = 2
 # individual findings. Shrink the list by fixing a rule in a file and
 # dropping its code here.
 "plugin_cmds/cmd_decrypt.py" = ["PLR0917"]
-"src/audible_cli/cmds/cmd_download.py" = ["ASYNC240", "C901", "PLR0917", "PLW0603", "PLW2901", "S101"]
+"src/audible_cli/cmds/cmd_download.py" = ["ASYNC240", "C901", "PLR0917", "PLW0603", "PLW2901"]
 "src/audible_cli/cmds/cmd_manage.py" = ["PLR0917"]
-"src/audible_cli/config.py" = ["B904"]
-"src/audible_cli/decorators.py" = ["B904"]
 "src/audible_cli/downloader.py" = ["PLR0917"]
-"src/audible_cli/models.py" = ["B904", "S101"]
 "src/audible_cli/utils.py" = ["PLR0917"]
-"utils/update_chapter_titles.py" = ["S101"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -27,6 +27,7 @@ from ..exceptions import (
     AudibleCliException,
     DirectoryDoesNotExists,
     DownloadUrlExpired,
+    LicenseDenied,
     NotDownloadableAsAAX,
     VoucherNeedRefresh,
 )
@@ -358,7 +359,9 @@ async def _reuse_voucher(lr_file, item):
     lr = json.loads(lr)
     content_license = lr["content_license"]
 
-    assert content_license["status_code"] == "Granted", "License not granted"
+    status_code = content_license["status_code"]
+    if status_code != "Granted":
+        raise LicenseDenied(f"License in {lr_file} is not granted: {status_code}")
 
     # try to get the user id
     user_id = None

--- a/src/audible_cli/config.py
+++ b/src/audible_cli/config.py
@@ -316,7 +316,9 @@ class Session:
                     hide_input=True,
                     default="")
                 if len(password) == 0:
-                    raise click.Abort()
+                    # Leaving the prompt empty is how the user asks to stop,
+                    # so the decryption error is not what caused the abort
+                    raise click.Abort() from None
 
         click_f = click.format_filename(auth_file, shorten=True)
         logger.debug("Auth file %s for profile %s loaded.", click_f, profile)

--- a/src/audible_cli/decorators.py
+++ b/src/audible_cli/decorators.py
@@ -85,7 +85,7 @@ def version_option(func=None, **kwargs):
             response.raise_for_status()
         except Exception as e:
             logger.error(e)
-            raise click.Abort()
+            raise click.Abort() from e
 
         content = response.json()
 

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -31,6 +31,12 @@ from .utils import (
 
 logger = logging.getLogger("audible_cli.models")
 
+# The download command restricts both through click.Choice, so a value outside
+# these reaches the item methods only from a plugin or another caller of the
+# API, which is why they answer with ValueError rather than a CLI error
+QUALITIES = ("best", "high", "normal")
+CHAPTER_TYPES = ("Flat", "Tree")
+
 
 class BaseItem:
     def __init__(
@@ -179,7 +185,8 @@ class LibraryItem(BaseItem):
         the codecs list. Otherwise, will find the best aax quality
         available.
         """
-        assert quality in ("best", "high", "normal",)
+        if quality not in QUALITIES:
+            raise ValueError(f"quality must be one of {QUALITIES}, not {quality!r}")
 
         # if available_codecs is None the item can't be downloaded as aax
         if self.available_codecs is None:
@@ -300,7 +307,7 @@ class LibraryItem(BaseItem):
         except Exception as e:
             raise AudibleCliException(
                 f"Can not get download url for asin {self.asin} with message {e}"
-            )
+            ) from e
 
         return httpx.URL(link), codec_name
 
@@ -353,7 +360,8 @@ class LibraryItem(BaseItem):
             quality: str = "high",
             response_groups: str | None = None
     ):
-        assert quality in ("best", "high", "normal",)
+        if quality not in QUALITIES:
+            raise ValueError(f"quality must be one of {QUALITIES}, not {quality!r}")
 
         if response_groups is None:
             response_groups = "last_position_heard, pdf_url, content_reference"
@@ -420,8 +428,12 @@ class LibraryItem(BaseItem):
         self, quality: str = "high", chapter_type: str = "Tree", **request_kwargs
     ):
         chapter_type = chapter_type.capitalize()
-        assert quality in ("best", "high", "normal",)
-        assert chapter_type in ("Flat", "Tree")
+        if quality not in QUALITIES:
+            raise ValueError(f"quality must be one of {QUALITIES}, not {quality!r}")
+        if chapter_type not in CHAPTER_TYPES:
+            raise ValueError(
+                f"chapter_type must be one of {CHAPTER_TYPES}, not {chapter_type!r}"
+            )
 
         url = f"content/{self.asin}/metadata"
         params = {

--- a/tests/test_models_arguments.py
+++ b/tests/test_models_arguments.py
@@ -1,0 +1,90 @@
+"""Argument checks on the item methods that download the audio.
+
+These were bare ``assert`` statements until the S101 cleanup, so ``python -O``
+dropped them and an unsupported value reached the API request instead of being
+refused. The tests pin the replacements down.
+"""
+
+import asyncio
+
+import pytest
+from helpers import FakeClient, library_item
+
+from audible_cli.cmds.cmd_download import cli as download_cli
+from audible_cli.models import CHAPTER_TYPES, QUALITIES, LibraryItem
+
+
+def sync(coro):
+    return asyncio.run(coro)
+
+
+def item():
+    return LibraryItem(library_item("B00TEST01"), api_client=FakeClient())
+
+
+BAD_QUALITIES = ["", "Best", "HIGH", "low", "aax", None]
+
+
+@pytest.mark.parametrize("quality", BAD_QUALITIES)
+def test_get_codec_refuses_unknown_quality(quality):
+    with pytest.raises(ValueError, match="quality"):
+        item()._get_codec(quality)
+
+
+@pytest.mark.parametrize("quality", BAD_QUALITIES)
+def test_get_license_refuses_unknown_quality(quality):
+    with pytest.raises(ValueError, match="quality"):
+        sync(item().get_license(quality))
+
+
+@pytest.mark.parametrize("quality", BAD_QUALITIES)
+def test_get_content_metadata_refuses_unknown_quality(quality):
+    with pytest.raises(ValueError, match="quality"):
+        sync(item().get_content_metadata(quality))
+
+
+@pytest.mark.parametrize("chapter_type", ["", "Nested", "flat tree", "Tree "])
+def test_get_content_metadata_refuses_unknown_chapter_type(chapter_type):
+    with pytest.raises(ValueError, match="chapter_type"):
+        sync(item().get_content_metadata("best", chapter_type=chapter_type))
+
+
+@pytest.mark.parametrize(
+    ("chapter_type", "expected"),
+    [("flat", "Flat"), ("TREE", "Tree"), ("tReE", "Tree"), ("Flat", "Flat")],
+)
+def test_get_content_metadata_keeps_accepting_any_casing(chapter_type, expected):
+    # capitalize() runs before the check, which is what makes the click option
+    # case_sensitive=False work. The check must not undo that, and the request
+    # must still carry the normalized value.
+    client = FakeClient()
+    item = LibraryItem(library_item("B00TEST01"), api_client=client)
+    sync(item.get_content_metadata("best", chapter_type=chapter_type))
+    assert client.last_params["params"]["chapter_titles_type"] == expected
+
+
+@pytest.mark.parametrize("quality", ["best", "high", "normal"])
+def test_get_codec_accepts_every_supported_quality(quality):
+    # Spelled out rather than parametrized over QUALITIES, so that dropping a
+    # value from the constant fails a test instead of silently shrinking it.
+    # No codecs on the item, so this returns early instead of reaching the API;
+    # what matters is that the check lets the value through.
+    assert item()._get_codec(quality) == (None, None)
+
+
+def choices_of(option_name):
+    param = next(p for p in download_cli.params if p.name == option_name)
+    return param.type.choices
+
+
+def test_the_supported_qualities_are_the_ones_the_cli_offers():
+    # Guards against the two drifting apart. If --quality gains a value that
+    # the item methods then reject, the download command breaks on an option
+    # its own help advertises.
+    assert set(QUALITIES) == set(choices_of("quality"))
+
+
+def test_the_supported_chapter_types_are_the_ones_the_cli_offers():
+    # "config" is resolved against the profile before any item method sees it,
+    # so it is the one choice that must not reach CHAPTER_TYPES.
+    assert set(CHAPTER_TYPES) == set(choices_of("chapter_type")) - {"config"}

--- a/tests/test_reuse_voucher.py
+++ b/tests/test_reuse_voucher.py
@@ -1,0 +1,61 @@
+"""The status check on a voucher file read back from disk.
+
+This was a bare ``assert`` until the S101 cleanup. Under ``python -O`` it was
+dropped, and a denied licence went on to be read for a download url instead of
+stopping the job.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from audible_cli.cmds.cmd_download import _reuse_voucher
+from audible_cli.exceptions import LicenseDenied
+
+
+def sync(coro):
+    return asyncio.run(coro)
+
+
+def voucher(tmp_path, status_code, **license_fields):
+    lr_file = tmp_path / "voucher.json"
+    content_license = {"status_code": status_code, **license_fields}
+    lr_file.write_text(json.dumps({"content_license": content_license}))
+    return lr_file
+
+
+GRANTED_CONTENT = {
+    "content_metadata": {
+        "content_url": {"offline_url": "https://example.invalid/book.aaxc"},
+        "content_reference": {"content_format": "AAX_44_128"},
+    }
+}
+
+
+class ItemWithoutClient:
+    """Enough of a ``LibraryItem`` for the code past the status check."""
+
+    _client = None
+
+
+@pytest.mark.parametrize("status_code", ["Denied", "Rejected", "granted", ""])
+def test_refuses_a_voucher_that_is_not_granted(tmp_path, status_code):
+    lr_file = voucher(tmp_path, status_code)
+    with pytest.raises(LicenseDenied) as excinfo:
+        sync(_reuse_voucher(lr_file, ItemWithoutClient()))
+
+    # The message has to name both the file and what it found, because the
+    # user has to decide whether to delete the voucher and request a new one
+    assert str(lr_file) in str(excinfo.value)
+    assert status_code in str(excinfo.value)
+
+
+def test_a_granted_voucher_is_read_back(tmp_path):
+    lr_file = voucher(tmp_path, "Granted", **GRANTED_CONTENT)
+
+    lr, url, codec = sync(_reuse_voucher(lr_file, ItemWithoutClient()))
+
+    assert str(url) == "https://example.invalid/book.aaxc"
+    assert codec == "AAX_44_128"
+    assert lr["content_license"]["status_code"] == "Granted"

--- a/utils/update_chapter_titles.py
+++ b/utils/update_chapter_titles.py
@@ -139,7 +139,12 @@ class FFMeta:
         if not isinstance(api_meta, ApiMeta):
             api_meta = ApiMeta(api_meta)
 
-        assert api_meta.count_chapters() == self.count_chapters()
+        if api_meta.count_chapters() != self.count_chapters():
+            raise ValueError(
+                f"Chapter count mismatch: the api meta file has "
+                f"{api_meta.count_chapters()}, the ffmetadata file "
+                f"{self.count_chapters()}."
+            )
 
         echo(f"Found {self.count_chapters()} chapters to prepare.")
 


### PR DESCRIPTION
Clears `B904` and `S101` from the Ruff baseline, which drops from 26 suppressed findings to 17 and takes four files off the list entirely.

### Why the `assert` statements mattered

Six of the nine findings were `assert` statements, and `python -O` removes those outright. Each was a check that vanished in exactly the setup a user might pick to make downloads faster.

The one in `_reuse_voucher` is the reason this is worth more than a lint fix:

```python
assert content_license["status_code"] == "Granted", "License not granted"
```

Under `-O` a denied licence went straight on to be read for a download url. It now raises `LicenseDenied` — a type the project already had — naming the file and the status it found.

Verified under `python -O` that all six now raise:

| Site | Now raises |
| --- | --- |
| `LibraryItem._get_codec` | `ValueError` |
| `LibraryItem.get_license` | `ValueError` |
| `get_content_metadata`, quality | `ValueError` |
| `get_content_metadata`, chapter_type | `ValueError` |
| `_reuse_voucher` | `LicenseDenied` |
| `FFMeta.update_title_from_api_meta` | `ValueError` |

### No change in control flow

Neither `AssertionError` nor `LicenseDenied` is caught around the `_reuse_voucher` call — only `DownloadUrlExpired` and `VoucherNeedRefresh` are. Both end up in the consumer's `except Exception`, so `--ignore-errors` and the exit code behave exactly as before. Only the message improves.

### Why `ValueError` and not `AudibleCliException`

The download command restricts `quality` and `chapter_type` through `click.Choice`, so a value outside them cannot come from the CLI. It can only come from a plugin or another caller of the API — a programming error, not a user-facing failure. `chapter_type.capitalize()` still runs before the check, so `--chapter-type` stays case-insensitive; there is a test for that.

### The three `B904` findings are not the same case

| File | Fix | Reason |
| --- | --- | --- |
| `config.py` | `from None` | An empty password prompt is how the user asks to stop, so the decryption error did not cause the abort |
| `decorators.py` | `from e` | The HTTP failure is the cause |
| `models.py` | `from e` | The message already interpolates `{e}` |

### Tests

35 new tests, 56 → 91. They cover the rejections, that every supported value still passes, that a granted voucher is read back with its url and codec, and that `--chapter-type` survives the new check in any casing.

### Noticed, deliberately not changed

`utils/update_chapter_titles.py` handles the same condition two opposite ways. `update_chapters_from_api_meta` warns on a chapter-count mismatch and asks whether to continue, commented "This happens on some of my books". `update_title_from_api_meta` — the path taken without `--separate-branding` — aborted on it. This PR keeps that behaviour and only gives it a real exception with both counts. Whether the default path should ask instead is a behaviour decision, not a lint fix.