### PR TITLE
refactor: name the CLI-only quality values as such

### DIFF
--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -13,6 +13,7 @@ import questionary
 from audible.exceptions import NotFoundError
 from click import echo
 
+from ..constants import API_CHAPTER_TYPES, CLI_CHAPTER_TYPE_CONFIG, QUALITIES
 from ..decorators import (
     bunch_size_option,
     end_date_option,
@@ -740,7 +741,7 @@ def display_counter():
     "--quality", "-q",
     default="best",
     show_default=True,
-    type=click.Choice(["best", "high", "normal"]),
+    type=click.Choice(QUALITIES),
     help="download quality"
 )
 @click.option(
@@ -769,7 +770,9 @@ def display_counter():
 @click.option(
     "--chapter-type",
     default="config",
-    type=click.Choice(["Flat", "Tree", "config"], case_sensitive=False),
+    type=click.Choice(
+        [*API_CHAPTER_TYPES, CLI_CHAPTER_TYPE_CONFIG], case_sensitive=False
+    ),
     help="The chapter type."
 )
 @click.option(
@@ -914,7 +917,7 @@ async def cli(session, api_client, **params):
         logger.info("Selected end date: %s", end_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
 
     chapter_type = params.get("chapter_type")
-    if chapter_type == "config":
+    if chapter_type == CLI_CHAPTER_TYPE_CONFIG:
         chapter_type = session.config.get_profile_option(
             session.selected_profile, "chapter_type") or "Tree"
 

--- a/src/audible_cli/constants.py
+++ b/src/audible_cli/constants.py
@@ -18,6 +18,29 @@ DEFAULT_CONFIG_DATA: dict[str, str] = {
 CODEC_HIGH_QUALITY: str = "AAX_44_128"
 CODEC_NORMAL_QUALITY: str = "AAX_44_64"
 
+# The only two values this client ever sends as the quality of a license or
+# metadata request
+API_QUALITY_HIGH: str = "High"
+API_QUALITY_NORMAL: str = "Normal"
+
+# What `--quality` accepts, and what each value is sent as. "best" never
+# crosses the wire under that name: it is a client-side choice that selects
+# the best aax entry from an item's `available_codecs`, while the request
+# itself goes out as High. Aaxc does not go through that selection for its
+# format and takes it from the license response.
+QUALITY_TO_API: dict[str, str] = {
+    "best": API_QUALITY_HIGH,
+    "high": API_QUALITY_HIGH,
+    "normal": API_QUALITY_NORMAL,
+}
+QUALITIES: tuple[str, ...] = tuple(QUALITY_TO_API)
+
+# The chapter styles a metadata request is built with. `--chapter-type` accepts
+# one more, "config", which the download command resolves against the profile
+# before any request exists.
+API_CHAPTER_TYPES: tuple[str, ...] = ("Flat", "Tree")
+CLI_CHAPTER_TYPE_CONFIG: str = "config"
+
 AVAILABLE_MARKETPLACES = [
     market["country_code"] for market in LOCALE_TEMPLATES.values()
 ]

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -13,7 +13,13 @@ import httpx
 from audible.aescipher import decrypt_voucher_from_licenserequest
 from audible.client import convert_response_content
 
-from .constants import CODEC_HIGH_QUALITY, CODEC_NORMAL_QUALITY
+from .constants import (
+    API_CHAPTER_TYPES,
+    CODEC_HIGH_QUALITY,
+    CODEC_NORMAL_QUALITY,
+    QUALITIES,
+    QUALITY_TO_API,
+)
 from .exceptions import (
     AudibleCliException,
     ItemNotPublished,
@@ -31,11 +37,27 @@ from .utils import (
 
 logger = logging.getLogger("audible_cli.models")
 
-# The download command restricts both through click.Choice, so a value outside
-# these reaches the item methods only from a plugin or another caller of the
-# API, which is why they answer with ValueError rather than a CLI error
-QUALITIES = ("best", "high", "normal")
-CHAPTER_TYPES = ("Flat", "Tree")
+
+def api_quality(quality: str) -> str:
+    """Return what a request sends for this `--quality` value.
+
+    "best" is not sent under that name. On the aax path it selects the best
+    entry from the item's `available_codecs`, in `LibraryItem._get_codec`,
+    while the request goes out as High. An aaxc download does not go through
+    that selection for its format at all and takes it from the license
+    response.
+
+    Raises:
+        ValueError: if `quality` is not one of `QUALITIES`. Refusing beats
+            guessing, because either fallback would silently request a quality
+            the caller never asked for.
+    """
+    try:
+        return QUALITY_TO_API[quality]
+    except (KeyError, TypeError):
+        raise ValueError(
+            f"quality must be one of {QUALITIES}, not {quality!r}"
+        ) from None
 
 
 class BaseItem:
@@ -368,7 +390,7 @@ class LibraryItem(BaseItem):
 
         body = {
             "supported_drm_types": ["Mpeg", "Adrm"],
-            "quality": "High" if quality in ("best", "high") else "Normal",
+            "quality": api_quality(quality),
             "consumption_type": "Download",
             "response_groups": response_groups
         }
@@ -430,16 +452,16 @@ class LibraryItem(BaseItem):
         chapter_type = chapter_type.capitalize()
         if quality not in QUALITIES:
             raise ValueError(f"quality must be one of {QUALITIES}, not {quality!r}")
-        if chapter_type not in CHAPTER_TYPES:
+        if chapter_type not in API_CHAPTER_TYPES:
             raise ValueError(
-                f"chapter_type must be one of {CHAPTER_TYPES}, not {chapter_type!r}"
+                f"chapter_type must be one of {API_CHAPTER_TYPES}, not {chapter_type!r}"
             )
 
         url = f"content/{self.asin}/metadata"
         params = {
             "response_groups": "last_position_heard, content_reference, "
                                "chapter_info",
-            "quality": "High" if quality in ("best", "high") else "Normal",
+            "quality": api_quality(quality),
             "drm_type": "Adrm",
             "chapter_titles_type": chapter_type,
             **request_kwargs

--- a/tests/test_models_arguments.py
+++ b/tests/test_models_arguments.py
@@ -10,8 +10,8 @@ import asyncio
 import pytest
 from helpers import FakeClient, library_item
 
-from audible_cli.cmds.cmd_download import cli as download_cli
-from audible_cli.models import CHAPTER_TYPES, QUALITIES, LibraryItem
+from audible_cli.constants import CLI_CHAPTER_TYPE_CONFIG, QUALITIES
+from audible_cli.models import LibraryItem, api_quality
 
 
 def sync(coro):
@@ -72,19 +72,44 @@ def test_get_codec_accepts_every_supported_quality(quality):
     assert item()._get_codec(quality) == (None, None)
 
 
-def choices_of(option_name):
-    param = next(p for p in download_cli.params if p.name == option_name)
-    return param.type.choices
+@pytest.mark.parametrize(
+    ("quality", "sent"),
+    [
+        # Spelled out rather than taken from the constants, so that changing a
+        # wire value has to be a deliberate edit here too
+        ("normal", "Normal"),
+        ("high", "High"),
+        # "best" never crosses the wire under that name
+        ("best", "High"),
+    ],
+)
+def test_quality_is_translated_for_the_api(quality, sent):
+    assert api_quality(quality) == sent
+
+    client = FakeClient()
+    item = LibraryItem(library_item("B00TEST01"), api_client=client)
+    sync(item.get_content_metadata(quality))
+    assert client.last_params["params"]["quality"] == sent
 
 
-def test_the_supported_qualities_are_the_ones_the_cli_offers():
-    # Guards against the two drifting apart. If --quality gains a value that
-    # the item methods then reject, the download command breaks on an option
-    # its own help advertises.
-    assert set(QUALITIES) == set(choices_of("quality"))
+def test_every_supported_quality_is_sent_as_high_or_normal():
+    # The set the API is given is smaller than the set the CLI offers, which
+    # is the whole reason api_quality exists
+    assert set(map(api_quality, QUALITIES)) == {"High", "Normal"}
 
 
-def test_the_supported_chapter_types_are_the_ones_the_cli_offers():
-    # "config" is resolved against the profile before any item method sees it,
-    # so it is the one choice that must not reach CHAPTER_TYPES.
-    assert set(CHAPTER_TYPES) == set(choices_of("chapter_type")) - {"config"}
+@pytest.mark.parametrize("quality", BAD_QUALITIES)
+def test_api_quality_refuses_what_it_cannot_translate(quality):
+    # It is reachable from a plugin without going through a method that
+    # validates first, so it has to refuse rather than fall back to a quality
+    # nobody asked for
+    with pytest.raises(ValueError, match="quality"):
+        api_quality(quality)
+
+
+def test_config_never_reaches_a_metadata_request():
+    # --chapter-type accepts it, but the download command resolves it against
+    # the profile first. Reaching an item method means that resolution was
+    # skipped, so it has to be refused rather than sent as a chapter style.
+    with pytest.raises(ValueError, match="chapter_type"):
+        sync(item().get_content_metadata("best", chapter_type=CLI_CHAPTER_TYPE_CONFIG))


### PR DESCRIPTION
`--quality` accepts `best`, `high` and `normal`, but a license or metadata request only ever goes out as `High` or `Normal`. `best` is a client-side choice: on the aax path it selects the best entry from the item's `available_codecs`, while the request itself is sent as `High`. An aaxc download does not go through that selection for its format at all and takes it from the license response.

Nothing in the code said so. The translation

```python
"quality": "High" if quality in ("best", "high") else "Normal"
```

sat inline in `get_license` and again in `get_content_metadata` — unnamed, and in two places at once.

### Changes

| File | Change |
| --- | --- |
| `constants.py` | `QUALITY_TO_API` holds the mapping; `QUALITIES` is derived from its keys. The chapter types move here too, split the same way into `API_CHAPTER_TYPES` and `CLI_CHAPTER_TYPE_CONFIG` |
| `models.py` | New `api_quality()`, the single entry point for the translation |
| `cmd_download.py` | Both `click.Choice` lists are built from the constants instead of repeating the literals |

Deriving `QUALITIES` from the mapping keys means the set the CLI offers cannot drift from the set that can be translated. Dicts keep insertion order, so `--help` still reads `[best|high|normal]`.

### What `api_quality()` refuses, and why that is not a breaking change

The new function raises `ValueError` for anything outside `QUALITIES` rather than falling through to `Normal`, the way the inline expression did. Silently requesting a quality nobody asked for is worse than refusing.

That is a contract decision about new code, not a change to released behaviour, and it needs no changelog entry:

- Neither exists in v0.5.0. `QUALITIES` arrived on master with #289 and is still unreleased; `api_quality()` is introduced by this PR, so it has no released behaviour to change.
- On master, `get_license` and `get_content_metadata` already reject an unknown quality before the translation runs, so the old fall-through was unreachable for those inputs anyway.
- `click.Choice` rejects it earlier still, so the CLI never gets near it.

The behaviour that *was* released and *did* change is in #289, where these checks stopped being `assert` statements that `python -O` removed.

### Not changed

Option order, case handling and the `best` default are untouched. `--help` was captured on master and on this branch and compared with `cmp`: byte-identical, 3534 bytes. `_get_codec` is not touched at all.

### Verification

`ruff check`, `ruff format --check` and 101 tests pass. The tests pin the wire values as literals rather than reading them back from the constants, so changing one has to be a deliberate edit in two places.

Measured against a real library of 170 titles and 570 vouchers while writing this: every item that has codecs offers `aax_44_128`, so `best` and `high` resolve identically there, and every voucher came back as `AAX_44_128`. `best` earns its place as the only choice not tied to a hardcoded codec name — not as a fallback.


