### PR TITLE
fix: verify the size of a finished download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `build_auth_file()` no longer raises an `AttributeError` when its `filename` is passed as a `str`, which its signature allows. The failure happened after the login had already registered the device, so the registration was lost without the auth file being written
 - The `convert-oa-file` plugin works again. It has failed to even load since v0.2 because it imported `pass_session` from the wrong module, and behind that sat a tuple passed to `pathlib.Path()`, a call to a `Session` method that does not exist, an expiry read as seconds although OpenAudible writes milliseconds, a `KeyError` on cookie fields that are optional, and a profile name from the converted file that could write outside the config directory
+- The size of a finished audiobook download is checked again. The check existed but nothing ever called it, so a file that arrived at a different length than announced was renamed to its final name and counted as a success. Covers and PDFs take the older download path and were never affected
 
 ## [0.5.0] - 2026-08-05
 

--- a/src/audible_cli/downloader.py
+++ b/src/audible_cli/downloader.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("audible_cli.downloader")
 
 ACCEPT_RANGES_HEADER = "Accept-Ranges"
 ACCEPT_RANGES_NONE_VALUE = "none"
+CONTENT_ENCODING_HEADER = "Content-Encoding"
 CONTENT_LENGTH_HEADER = "Content-Length"
 CONTENT_TYPE_HEADER = "Content-Type"
 MAX_FILE_READ_SIZE = 3 * 1024 * 1024
@@ -170,9 +171,30 @@ async def check_target_file_status(
     return Status.Success
 
 
+def _is_content_encoded(response: ResponseInfo | None) -> bool:
+    if response is None:
+        return False
+    encoding = response.headers.get(CONTENT_ENCODING_HEADER, "")
+    return encoding.strip().lower() not in ("", "identity")
+
+
 async def check_download_size(
-    tmp_file: File, target_file: File, head_response: ResponseInfo, **kwargs: Any
+    tmp_file: File,
+    target_file: File,
+    head_response: ResponseInfo,
+    response: ResponseInfo | None = None,
+    **kwargs: Any
 ) -> Status:
+    """Compare what landed on disk with the length that was announced.
+
+    Skipped for an encoded transfer: Content-Length may then describe the
+    encoded bytes while what reaches the file may have been decoded on the
+    way, so the two are not reliably comparable and the comparison could
+    reject a sound download.
+    """
+    if _is_content_encoded(head_response) or _is_content_encoded(response):
+        return Status.Success
+
     tmp_file_size = await tmp_file.get_size()
     content_length = head_response.content_length
 
@@ -185,7 +207,7 @@ async def check_download_size(
                 content_length,
                 tmp_file_size
             )
-        return Status.DownloadSizeMismatch
+            return Status.DownloadSizeMismatch
 
     return Status.Success
 
@@ -393,6 +415,7 @@ class Downloader:
             response=response,
             tmp_file=tmp_file,
             target_file=target_file,
+            head_response=head_response,
             expected_types=expected_types
         )
         if status != Status.Success:
@@ -412,11 +435,14 @@ class Downloader:
     ) -> DownloadResult:
         head_response = await self.get_head_response()
 
+        # Order matters. A text response is reported by its own message
+        # before anything measures it, and the size is only worth comparing
+        # once the response looked like the file we asked for.
         status_checks = [
             check_status_for_message,
             check_status_code,
-            check_status_code,
-            check_content_type
+            check_content_type,
+            check_download_size
         ]
         for check in status_checks:
             result = await self._check_and_return_download_result(

--- a/tests/test_download_size_check.py
+++ b/tests/test_download_size_check.py
@@ -1,0 +1,244 @@
+"""The size check that runs after a download finished.
+
+Three defects hid each other here. `check_download_size` was never in the
+postprocessing list, so nobody noticed that it reported a mismatch whenever
+both sizes were known, or that the dispatcher never handed it the head
+response it needs. The net effect was that a truncated audiobook was renamed
+to its final name and counted as a success.
+"""
+
+import asyncio
+import datetime
+
+import pytest
+
+from audible_cli.downloader import (
+    Downloader,
+    File,
+    ResponseInfo,
+    Status,
+    check_download_size,
+)
+
+
+def sync(coro):
+    return asyncio.run(coro)
+
+
+class FakeResponse:
+    """Enough of an httpx response for ResponseInfo."""
+
+    def __init__(self, content_length=None, content_type="audio/aax", status_code=200):
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+        if content_type is not None:
+            self.headers["Content-Type"] = content_type
+        self.status_code = status_code
+        self.url = "https://example.invalid/book.aaxc"
+        self.request = None
+        self.history = []
+        self.elapsed = datetime.timedelta(seconds=1)
+
+
+def head_for(content_length):
+    return ResponseInfo(FakeResponse(content_length=content_length))
+
+
+def written(tmp_path, size):
+    f = tmp_path / "book.aaxc.tmp"
+    f.write_bytes(b"x" * size)
+    return File(f)
+
+
+@pytest.mark.parametrize("size", [0, 1, 4096, 10_000_000])
+def test_matching_size_passes(tmp_path, size):
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, size),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head_for(size),
+        )
+    )
+    assert status is Status.Success
+
+
+@pytest.mark.parametrize(
+    ("written_size", "expected_size"),
+    [
+        (500, 1000),  # truncated, the case that matters
+        (0, 1000),  # nothing arrived at all
+        (1000, 500),  # more than announced
+    ],
+)
+def test_differing_size_is_reported(tmp_path, written_size, expected_size):
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, written_size),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head_for(expected_size),
+        )
+    )
+    assert status is Status.DownloadSizeMismatch
+
+
+def test_unknown_content_length_cannot_fail(tmp_path):
+    # No Content-Length means nothing to compare against, which must not be
+    # turned into a failure.
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, 1234),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head_for(None),
+        )
+    )
+    assert status is Status.Success
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        "gzip",
+        "br",  # brotli
+        "zstd",
+        "deflate",
+        "compress",
+        "gzip, br",  # chained
+        " BR ",  # the header is case-insensitive and may carry spaces
+        "x-gzip",
+        "something-nobody-has-heard-of",
+    ],
+)
+def test_an_encoded_transfer_is_not_measured(tmp_path, encoding):
+    # Content-Length may describe the encoded bytes while what reaches the
+    # file may have been decoded, so the comparison could reject a sound
+    # download. Which scheme it is does not matter, so this is an allowlist:
+    # everything that is not plain counts as encoded, including schemes that
+    # do not exist yet.
+    head = ResponseInfo(FakeResponse(content_length=1000))
+    head.headers["Content-Encoding"] = encoding
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, 4000),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head,
+        )
+    )
+    assert status is Status.Success
+
+
+@pytest.mark.parametrize("encoding", ["identity", "IDENTITY", " identity "])
+def test_an_unencoded_transfer_is_still_measured(tmp_path, encoding):
+    # `identity` means the bytes were not touched, so the two lengths do
+    # describe the same thing and a mismatch is a real one.
+    head = ResponseInfo(FakeResponse(content_length=1000))
+    head.headers["Content-Encoding"] = encoding
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, 4000),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head,
+        )
+    )
+    assert status is Status.DownloadSizeMismatch
+
+
+def test_the_encoding_may_sit_on_either_response(tmp_path):
+    # The probe and the real request are separate exchanges; either one
+    # reporting an encoding makes the comparison meaningless.
+    head = ResponseInfo(FakeResponse(content_length=1000))
+    actual = ResponseInfo(FakeResponse(content_length=1000))
+    actual.headers["Content-Encoding"] = "br"
+    status = sync(
+        check_download_size(
+            tmp_file=written(tmp_path, 4000),
+            target_file=File(tmp_path / "book.aaxc"),
+            head_response=head,
+            response=actual,
+        )
+    )
+    assert status is Status.Success
+
+
+# --- the wiring, proven through behaviour rather than by reading source ---
+
+
+def postprocess(tmp_path, written_size, announced_size, content_type="audio/aax"):
+    """Run the real _postprocessing over a prepared tmp file."""
+    dl = Downloader(
+        source="https://example.invalid/book.aaxc",
+        client=None,
+        expected_types=["audio/aax"],
+    )
+    head = ResponseInfo(FakeResponse(content_length=announced_size))
+
+    async def fake_head(force_recreate=False):
+        return head
+
+    dl.get_head_response = fake_head
+
+    tmp_file = written(tmp_path, written_size)
+    target_file = File(tmp_path / "book.aaxc")
+    response = ResponseInfo(
+        FakeResponse(content_length=announced_size, content_type=content_type)
+    )
+    return sync(
+        dl._postprocessing(
+            tmp_file=tmp_file,
+            target_file=target_file,
+            response=response,
+            force_reload=False,
+        )
+    )
+
+
+def test_postprocessing_rejects_a_short_download(tmp_path):
+    # Fails if the check is not in the list, and also if head_response is
+    # not handed to it — that would raise TypeError instead.
+    result = postprocess(tmp_path, written_size=500, announced_size=1000)
+
+    assert result.status is Status.DownloadSizeMismatch
+    assert not (tmp_path / "book.aaxc").exists(), "must not become the real file"
+
+
+def test_postprocessing_accepts_a_complete_download(tmp_path):
+    result = postprocess(tmp_path, written_size=1000, announced_size=1000)
+
+    assert result.status is Status.Success
+    assert (tmp_path / "book.aaxc").exists()
+
+
+def test_a_parts_message_still_wins_over_the_size(tmp_path):
+    # The text response is far shorter than announced. It has to be reported
+    # through its own message, so the caller still learns the book must be
+    # fetched in parts instead of being told the size was wrong.
+    dl = Downloader(
+        source="https://example.invalid/book.aaxc",
+        client=None,
+        expected_types=["audio/aax"],
+    )
+    head = ResponseInfo(FakeResponse(content_length=99999))
+
+    async def fake_head(force_recreate=False):
+        return head
+
+    dl.get_head_response = fake_head
+
+    # Must contain the exact phrase the detection looks for, lowercase.
+    message = "Sorry, please download individual parts for this title."
+    tmp_file = File(tmp_path / "book.aaxc.tmp")
+    tmp_file.path.write_text(message, encoding="utf-8")
+    response = ResponseInfo(
+        FakeResponse(content_length=len(message), content_type="text/plain")
+    )
+    result = sync(
+        dl._postprocessing(
+            tmp_file=tmp_file,
+            target_file=File(tmp_path / "book.aaxc"),
+            response=response,
+            force_reload=False,
+        )
+    )
+
+    assert result.status is Status.DownloadIndividualParts
+    assert not (tmp_path / "book.aaxc").exists()


### PR DESCRIPTION
The download size was never checked. `check_download_size` existed but nothing called it — the postprocessing list held `check_status_code` twice, once in the slot the size check belonged in:

```python
status_checks = [
    check_status_for_message,
    check_status_code,
    check_status_code,      # ← where check_download_size belonged
    check_content_type
]
```

So an audiobook that arrived at a different length than announced was renamed to its final name and counted as a success.

### Three defects, each hiding the next

| | Defect | Why it stayed hidden |
| --- | --- | --- |
| 1 | `check_download_size` missing from `_postprocessing` | The duplicate `check_status_code` made the list look full |
| 2 | Its `return Status.DownloadSizeMismatch` sat outside the comparison, firing even when the sizes matched | Never called, so never observed |
| 3 | `_check_and_return_download_result` never passed `head_response` — the one argument the check needs | Wiring it up would have raised `TypeError`, not checked anything |

Fixing any one alone does nothing useful. Fixing 1 without 2 would have failed every download.

The old `utils.Downloader` does check the size (`utils.py:279`), so covers and PDFs were covered while the audiobooks — what the tool exists for — were not.

### What it catches, and what it does not

**Catches:** a download whose final length differs from the one the preceding request announced.

**Not a mid-transfer cut.** httpx already rejects a response that ends early against its own `Content-Length`, raising `RemoteProtocolError` before postprocessing runs. Verified.

**Encoded transfers are skipped, whichever scheme.** `Content-Length` may then describe the encoded bytes while what reaches the file may have been decoded on the way. The guard asks whether the transfer was plain rather than listing schemes, so `gzip`, `deflate`, `br`, `zstd`, chained values like `gzip, br` and anything added later all skip the comparison; only an absent header and `identity` reach it.

### Deliberately out of scope

Parsing `Content-Range`, insisting on `206` for a resumed request, and tying the two requests together with `If-Range`. Those harden resume itself and belong with the downloader rework. Size alone does not prove the content is right; it catches the length going wrong.

### Verification

24 new tests, 101 → 125. Each defect and the encoding guard was reintroduced individually to confirm the tests fail. The wiring is proven through behaviour rather than by reading source: `_postprocessing` runs over a prepared temp file and must return `DownloadSizeMismatch` *and* leave the target absent.

Encoding matrix: 9 schemes skip the comparison, 3 spellings of `identity` still reach it, and an encoding on either the probe or the real response is enough to skip.

Smoke tested against the real API in a temp directory:

| Case | Result |
| --- | --- |
| Cover, chapters (old downloader path) | unchanged |
| aaxc, 1.7 GB streamed | `Success`, no false positive, no leftovers |
| aaxc, 32 MB in one go | `Success` |
| 250 MB, aborted at 40 MB, restarted | resumed from `38.9M/250M`, `Success`, MP4 box chain `ftyp → moov → mdat` ends exactly flush with the file size |
| gzip / deflate transfer | `Success`, comparison correctly skipped |