### PR TITLE
ci: stop caching uv on the release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,12 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        # A cache saved under one tag is not readable from another, and this
+        # workflow only ever runs on a tag, so it would upload caches no later
+        # release can reuse. The duplicate macOS and Windows jobs can also race
+        # for the one key they share.
+        enable-cache: false
 
     - name: Build with pyinstaller for ${{matrix.TARGET}}
       run: ${{matrix.CMD_BUILD}}


### PR DESCRIPTION
The v0.5.1 build logged two warnings, one for macOS and one for Windows:

```
Failed to save: Unable to reserve cache with key
setup-uv-2-aarch64-apple-darwin-macos-16-3.14.6-0433b6d…,
another job may be creating this cache.
```

### Where they come from

The matrix runs `macos-latest` twice and `windows-latest` twice — once for the one-file build, once for the one-directory build. Each pair uses the same runner image and the same lock file, so both jobs derive one cache key and can race to reserve it. The logs of the two macOS jobs show how it played out:

| Job | Outcome |
| --- | --- |
| `-D` | `uv cache saved with key: setup-uv-2-aarch64-…` |
| `-F` | `Failed to save: Unable to reserve cache with key …` |

The two Ubuntu jobs ask for different images (`ubuntu-latest` and `ubuntu-22.04`), so their keys differed and neither warned.

### Why off, rather than a distinct key per job

What this workflow saves cannot come back. Actions scopes a cache to the ref that wrote it, so a cache written under `v0.5.1` is unreadable from `v0.5.2`; only a rerun of the same tag could read it.

Restoring is a different matter — a tag run can still hit a cache written on the default branch — but that gain is small for a workflow that runs a handful of times a year, and every miss still uploads a cache no later tag can read.

A per-job `cache-suffix` would silence the warning too, but it would store the same content twice.

### Left alone

- `tests.yml` and `uv-lock-maintenance.yml` already set `enable-cache: true` and run where reuse is possible.
- `pypi-publish.yml` and `pypi-publish-test.yml` stay on the default. They run once per release against master and have no competing matrix jobs.

### A note on the default

`setup-uv` is pinned at `v9.0.0`, where `enable-cache: auto` means nothing more than "GitHub-hosted runner" — it does not look at the event. The tag-push exemption described in the action's current README landed in v10, which is why a tag build cached at all.

### Verification

YAML parses, `enable-cache` reaches the step. The effect is only visible on the next release build, since this workflow runs on tag push alone.