### PR TITLE
ci: let the release build run without a tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  # Lets the build be exercised without cutting a release. A dispatched run
+  # works the matrix and keeps what it produced as workflow artifacts; it
+  # never touches a release. Everything that writes to a release asks for
+  # both the push event and a v-tag ref: the event alone would let a future
+  # branch push through, the ref alone would let a dispatch aimed at a tag
+  # publish one.
+  workflow_dispatch:
 
 # Required by action-gh-release to create, upload to and publish the release
 permissions:
@@ -15,6 +22,7 @@ env:
 jobs:
   create_release:
     name: Create Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
     - name: Create draft release
@@ -32,6 +40,9 @@ jobs:
   build:
     name: Build packages
     needs: create_release
+    # A skipped dependency would skip this too, so spell out that a skip is
+    # acceptable while a failure or a cancellation is not
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -89,10 +100,10 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:
-        # A cache saved under one tag is not readable from another, and this
-        # workflow only ever runs on a tag, so it would upload caches no later
-        # release can reuse. The duplicate macOS and Windows jobs can also race
-        # for the one key they share.
+        # A cache saved under one tag is not readable from another, and a
+        # release only ever runs from a tag, so it would upload caches no
+        # later release can reuse. The duplicate macOS and Windows jobs can
+        # also race for the one key they share.
         enable-cache: false
 
     - name: Build with pyinstaller for ${{matrix.TARGET}}
@@ -100,6 +111,7 @@ jobs:
 
     - name: Upload Release Asset
       id: upload-release-asset
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v3
       with:
         files: ./dist/${{ matrix.OUT_FILE_NAME}}
@@ -111,11 +123,20 @@ jobs:
         # from swapping good assets for ones no build step has verified.
         overwrite_files: false
 
+    - name: Keep the build for inspection
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.OUT_FILE_NAME }}
+        path: ./dist/${{ matrix.OUT_FILE_NAME }}
+        if-no-files-found: error
+
   publish_release:
     name: Publish Release
     # Only reached when all six builds succeeded, so a failed matrix leaves
     # the draft behind instead of a public release with missing assets
     needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
     - name: Publish the draft release


### PR DESCRIPTION
The build workflow only ever triggered on a tag push, so nothing about it could be tried out before a release depended on it. A change to the matrix — a new runner, a new target — was first exercised by the release that needed it to work.

That is the situation right now: the next step is an Intel macOS job, and without this there is no way to find out whether it works except by tagging a release and hoping.

### What a dispatched run does

Works the matrix and keeps what it produced as workflow artifacts. It creates no release, attaches no asset and publishes nothing.

| Job / step | On tag push | On dispatch |
| --- | --- | --- |
| `create_release` | runs | skipped |
| `build` | runs | runs |
| `Upload Release Asset` | runs | skipped |
| `Keep the build for inspection` | skipped | runs |
| any other event added later | nothing | — |
| `publish_release` | runs | skipped |

### Why both the event and the ref

Everything that writes to a release asks for `github.event_name == 'push'` **and** a ref under `refs/tags/v`:

- the event alone would let a branch push through, should anyone add `branches:` to the trigger later
- the ref alone would let a dispatch aimed at a tag publish a release, since a dispatch can be pointed at any ref and `softprops/action-gh-release` falls back to the ref when given no `tag_name`

Both are stated positively rather than as "not a dispatch". Excluding today's one harmless event would treat every event added later — `schedule`, `release`, `repository_dispatch` — as a release. For something that publishes, the list of what may do it should be the short one.

The artifact step asks for `workflow_dispatch` by name for the same reason: it says what the step is for, instead of inheriting whatever a future trigger might mean.

### Why `build` needs its own condition

It depends on `create_release`, and a skipped dependency skips the dependent job unless the condition says otherwise. `!failure() && !cancelled()` states that a skip is acceptable while a failure or a cancellation is not — so a dispatch builds, and a tag push whose release step failed does not.

### Also in here

The comment on the uv cache from #293 said this workflow only ever runs on a tag. This PR makes that untrue, so it now gives the reason that still holds: a *release* only ever runs from a tag.

### Verification

The YAML parses and the conditions resolve as tabulated above. Beyond that this cannot be tried before it is merged — [a workflow is only dispatchable once the file carrying the trigger sits on the default branch](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow). Merging it is the test; the first dispatch run afterwards proves it.
