### PR TITLE
ci: run each build before shipping it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
                 cd dist/ &&
                 zip -r9 audible_linux_ubuntu_latest audible
             OUT_FILE_NAME: audible_linux_ubuntu_latest.zip
+            EXE: dist/audible
           - os: ubuntu-22.04
             TARGET: linux
             CMD_BUILD: >
@@ -61,6 +62,7 @@ jobs:
                 cd dist/ &&
                 zip -r9 audible_linux_ubuntu_22_04 audible
             OUT_FILE_NAME: audible_linux_ubuntu_22_04.zip
+            EXE: dist/audible
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
@@ -68,6 +70,7 @@ jobs:
                 cd dist/ &&
                 zip -r9 audible_mac audible
             OUT_FILE_NAME: audible_mac.zip
+            EXE: dist/audible
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
@@ -75,6 +78,7 @@ jobs:
                 cd dist/ &&
                 zip -r9 audible_mac_dir audible
             OUT_FILE_NAME: audible_mac_dir.zip
+            EXE: dist/audible/audible
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
@@ -82,6 +86,7 @@ jobs:
                 cd dist/ &&
                 powershell Compress-Archive audible audible_win_dir.zip
             OUT_FILE_NAME: audible_win_dir.zip
+            EXE: dist/audible/audible.exe
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
@@ -89,6 +94,7 @@ jobs:
                 cd dist/ &&
                 powershell Compress-Archive audible.exe audible_win.zip
             OUT_FILE_NAME: audible_win.zip
+            EXE: dist/audible.exe
     steps:
     - uses: actions/checkout@v7
 
@@ -108,6 +114,17 @@ jobs:
 
     - name: Build with pyinstaller for ${{matrix.TARGET}}
       run: ${{matrix.CMD_BUILD}}
+
+    # Nothing here ever started the thing it ships. A build that cannot run
+    # on the machine that produced it has no business reaching a release,
+    # and that is the failure a new runner or architecture produces first.
+    - name: Check that the build runs
+      shell: bash
+      run: |
+        set -euo pipefail
+        out=$("${{ matrix.EXE }}" --help)
+        printf '%s\n' "$out"
+        grep -q '^Usage: audible' <<<"$out"
 
     - name: Upload Release Asset
       id: upload-release-asset


### PR DESCRIPTION
The release workflow never started what it published. A job counted as successful once PyInstaller had written a file and `zip` had packed it, so an artifact that cannot execute at all would still have been attached to a release and offered for download.

That matters now: the next change to this matrix adds new runners *and* new architectures, and "the binary does not run on the machine that built it" is exactly what those get wrong.

### What it checks

Each build runs `--help` and has to exit zero with the usual usage line:

```bash
set -euo pipefail
out=$("${{ matrix.EXE }}" --help)
printf '%s\n' "$out"
grep -q '^Usage: audible' <<<"$out"
```

No network, no credentials, no config. It says nothing about whether downloading works — only that the executable starts, finds its bundled interpreter and gets as far as parsing arguments.

### Where the paths come from

`EXE` is a matrix field rather than a derived path, because PyInstaller lays the two modes out differently. Both were read off the real v0.5.1 assets rather than assumed:

```
audible_linux_ubuntu_22_04.zip → audible
audible_win_dir.zip            → audible\audible.exe
                                 audible\_internal\…
```

| Entry | `EXE` |
| --- | --- |
| Linux, one-file | `dist/audible` |
| macOS, one-file | `dist/audible` |
| macOS, one-dir | `dist/audible/audible` |
| Windows, one-file | `dist/audible.exe` |
| Windows, one-dir | `dist/audible/audible.exe` |

### Deliberately not in here

**Which crypto backend the binary ended up with.** The provider is resolved per `Authenticator`, and `--help` never constructs one, so there is no way to observe it without credentials. It belongs with the platform change, where Windows arm64 has to fall back to `pycryptodome` because `cryptography` ships no `win_arm64` wheel — that is where getting it wrong would actually cost something.

**Asserting the architecture of the produced file.** Same reasoning: it guards against a moved `latest` label mislabelling an asset, which only becomes a real risk once the names carry the architecture.

### Verification

**Windows has no bash of its own**, so `shell: bash` there means the one shipped with Git for Windows — [documented](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell), but worth proving rather than trusting. A throwaway job on `windows-latest` ran the same shape as the smoke test — bash, a forward-slash relative path to an `.exe`, command substitution, herestring into `grep` — using the runner's own `python.exe` as a stand-in:

```
bash: 5.3.15(1)-release
Python 3.12.10
OK: bash, forward-slash .exe path, substitution and herestring all work
```

The probe has been removed again; only the smoke-test step remains.

The step was run against a real release artifact: `audible_linux_ubuntu_22_04.zip` from v0.5.1, unpacked and executed with the exact command above — exit 0, marker found.

The workflow itself cannot be proven by this PR, since the build only runs on a tag push or a dispatch. #294 made the dispatch possible, so it can be exercised on master right after merging.
