### PR TITLE
build: name the architecture, and build for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,56 +45,97 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # A broken runner should not hide the state of the others
+      fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             TARGET: linux
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                zip -r9 audible_linux_ubuntu_latest audible
-            OUT_FILE_NAME: audible_linux_ubuntu_latest.zip
+                zip -r9 audible_linux_ubuntu_24_04_x86_64 audible
+            OUT_FILE_NAME: audible_linux_ubuntu_24_04_x86_64.zip
+            LEGACY_NAME: audible_linux_ubuntu_latest.zip
+            EXE: dist/audible
+          - os: ubuntu-24.04-arm
+            TARGET: linux
+            CMD_BUILD: >
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                cd dist/ &&
+                zip -r9 audible_linux_ubuntu_24_04_arm64 audible
+            OUT_FILE_NAME: audible_linux_ubuntu_24_04_arm64.zip
             EXE: dist/audible
           - os: ubuntu-22.04
             TARGET: linux
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                zip -r9 audible_linux_ubuntu_22_04 audible
-            OUT_FILE_NAME: audible_linux_ubuntu_22_04.zip
+                zip -r9 audible_linux_ubuntu_22_04_x86_64 audible
+            OUT_FILE_NAME: audible_linux_ubuntu_22_04_x86_64.zip
+            LEGACY_NAME: audible_linux_ubuntu_22_04.zip
+            EXE: dist/audible
+          - os: ubuntu-22.04-arm
+            TARGET: linux
+            CMD_BUILD: >
+                uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                cd dist/ &&
+                zip -r9 audible_linux_ubuntu_22_04_arm64 audible
+            OUT_FILE_NAME: audible_linux_ubuntu_22_04_arm64.zip
             EXE: dist/audible
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                zip -r9 audible_mac audible
-            OUT_FILE_NAME: audible_mac.zip
+                zip -r9 audible_mac_arm64 audible
+            OUT_FILE_NAME: audible_mac_arm64.zip
+            LEGACY_NAME: audible_mac.zip
             EXE: dist/audible
           - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                zip -r9 audible_mac_dir audible
-            OUT_FILE_NAME: audible_mac_dir.zip
+                zip -r9 audible_mac_arm64_dir audible
+            OUT_FILE_NAME: audible_mac_arm64_dir.zip
+            LEGACY_NAME: audible_mac_dir.zip
             EXE: dist/audible/audible
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -D --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                powershell Compress-Archive audible audible_win_dir.zip
-            OUT_FILE_NAME: audible_win_dir.zip
+                powershell Compress-Archive audible audible_win_x86_64_dir.zip
+            OUT_FILE_NAME: audible_win_x86_64_dir.zip
+            LEGACY_NAME: audible_win_dir.zip
             EXE: dist/audible/audible.exe
           - os: windows-latest
             TARGET: windows
             CMD_BUILD: >
                 uv run --locked --extra cryptography pyinstaller --clean -F --hidden-import audible_cli --collect-all cryptography --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
                 cd dist/ &&
-                powershell Compress-Archive audible.exe audible_win.zip
-            OUT_FILE_NAME: audible_win.zip
+                powershell Compress-Archive audible.exe audible_win_x86_64.zip
+            OUT_FILE_NAME: audible_win_x86_64.zip
+            LEGACY_NAME: audible_win.zip
             EXE: dist/audible.exe
+          - os: windows-11-arm
+            TARGET: windows
+            CMD_BUILD: >
+                uv run --locked --extra pycryptodome pyinstaller --clean -D --hidden-import audible_cli --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                cd dist/ &&
+                powershell Compress-Archive audible audible_win_arm64_dir.zip
+            OUT_FILE_NAME: audible_win_arm64_dir.zip
+            EXE: dist/audible/audible.exe
+          - os: windows-11-arm
+            TARGET: windows
+            CMD_BUILD: >
+                uv run --locked --extra pycryptodome pyinstaller --clean -F --hidden-import audible_cli --collect-submodules audible.crypto_provider -n audible -c pyi_entrypoint.py &&
+                cd dist/ &&
+                powershell Compress-Archive audible.exe audible_win_arm64.zip
+            OUT_FILE_NAME: audible_win_arm64.zip
+            EXE: dist/audible.exe
+
     steps:
     - uses: actions/checkout@v7
 
@@ -126,6 +167,16 @@ jobs:
         printf '%s\n' "$out"
         grep -q '^Usage: audible' <<<"$out"
 
+    # The names gained an architecture, and a /releases/latest/download
+    # link only resolves the exact name it was given. Publishing the same
+    # file twice keeps links that were copied before this change working.
+    # Retires after 15 November 2026, and not before two stable releases
+    # have carried both names.
+    - name: Also stage the retiring name
+      if: matrix.LEGACY_NAME != ''
+      shell: bash
+      run: cp "dist/${{ matrix.OUT_FILE_NAME }}" "dist/${{ matrix.LEGACY_NAME }}"
+
     - name: Upload Release Asset
       id: upload-release-asset
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -140,6 +191,17 @@ jobs:
         # from swapping good assets for ones no build step has verified.
         overwrite_files: false
 
+    - name: Upload Release Asset under the retiring name
+      if: >
+        matrix.LEGACY_NAME != '' && github.event_name == 'push'
+        && startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v3
+      with:
+        files: ./dist/${{ matrix.LEGACY_NAME }}
+        draft: true
+        fail_on_unmatched_files: true
+        overwrite_files: false
+
     - name: Keep the build for inspection
       if: github.event_name == 'workflow_dispatch'
       uses: actions/upload-artifact@v7
@@ -150,8 +212,8 @@ jobs:
 
   publish_release:
     name: Publish Release
-    # Only reached when all six builds succeeded, so a failed matrix leaves
-    # the draft behind instead of a public release with missing assets
+    # Only reached when every build succeeded, so a failed matrix leaves the
+    # draft behind instead of a public release with missing assets
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Standalone builds for arm64 on Linux and Windows, alongside the existing x86_64 ones. macOS was already Apple silicon only and stays that way; on an Intel Mac install from PyPI instead
+- The download names now carry the architecture, for example `audible_win_x86_64.zip` and `audible_win_arm64.zip`. The Linux build that was named `latest` now names the Ubuntu release it is built on, 24.04, because the runner is pinned to it. The previous names are published alongside the new ones and will be dropped after 15 November 2026, so existing download links keep working until then
+- A `pycryptodome` extra, used by the Windows arm64 build because `cryptography` publishes no wheel for that platform. Both are accelerated; only the implementation differs
+
 ## [0.5.1] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,11 +103,24 @@ Without the extra, audible-cli still works using the pure-Python fallback.
 Don’t want to install Python?  
 Prebuilt binaries are available on the [releases page](https://github.com/mkb79/audible-cli/releases).
 
-> ℹ️ The prebuilt binaries already **bundle the Rust-accelerated `cryptography` backend** (statically linked, no extra setup) — so cryptographic operations are fast out of the box.
+> ℹ️ The prebuilt binaries bundle an accelerated crypto backend, with no
+> extra setup — the Rust-based `cryptography` everywhere except Windows on
+> arm64, which uses `pycryptodome` because `cryptography` publishes no wheel
+> for it. Either way you are not on the slow pure-Python fallback.
 
-- **Windows:** [onedir](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win_dir.zip) (recommended), [onefile](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win.zip)  
-- **Linux:** [Ubuntu 22.04](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_22_04.zip), [latest](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_latest.zip)  
-- **macOS:** [onefile](https://github.com/mkb79/audible-cli/releases/latest/download/audible_mac.zip), [onedir](https://github.com/mkb79/audible-cli/releases/latest/download/audible_mac_dir.zip)  
+**Windows** — [x86_64 onedir](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win_x86_64_dir.zip) (recommended), [x86_64 onefile](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win_x86_64.zip)  
+Also on ARM: [arm64 onedir](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win_arm64_dir.zip), [arm64 onefile](https://github.com/mkb79/audible-cli/releases/latest/download/audible_win_arm64.zip)
+
+**macOS** — Apple silicon only: [onefile](https://github.com/mkb79/audible-cli/releases/latest/download/audible_mac_arm64.zip), [onedir](https://github.com/mkb79/audible-cli/releases/latest/download/audible_mac_arm64_dir.zip)  
+On an Intel Mac, install from PyPI instead: `pipx install audible-cli`
+
+**Linux** — take these: [x86_64](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_22_04_x86_64.zip), [arm64](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_22_04_arm64.zip)  
+Built on Ubuntu 22.04, so they need glibc 2.35 — Ubuntu 22.04, Debian 12, RHEL 9 and anything newer.  
+There are also builds on a 24.04 base ([x86_64](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_24_04_x86_64.zip), [arm64](https://github.com/mkb79/audible-cli/releases/latest/download/audible_linux_ubuntu_24_04_arm64.zip)). They need glibc 2.38 and so reach fewer systems; take one only if you have a reason to.
+
+> ℹ️ The download names now carry the architecture. The old names without one
+> (`audible_mac.zip`, `audible_win.zip` and the rest) are still published
+> alongside and will be dropped after 15 November 2026.
 
 ⚠️ *On Windows, prefer the **onedir** build for faster startup.*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ documentation = "https://audible-cli.readthedocs.io/"
 cryptography = [
     "audible[cryptography]>=0.11.0",
 ]
+# For platforms cryptography publishes no wheel for, currently Windows on
+# arm64. Same job, different implementation, both faster than the pure
+# Python fallback.
+pycryptodome = [
+    "audible[pycryptodome]>=0.11.0",
+]
 
 [project.urls]
 Changelog = "https://github.com/mkb79/audible-cli/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,9 @@ wheels = [
 cryptography = [
     { name = "cryptography" },
 ]
+pycryptodome = [
+    { name = "pycryptodome" },
+]
 
 [[package]]
 name = "audible-cli"
@@ -77,6 +80,9 @@ dependencies = [
 cryptography = [
     { name = "audible", extra = ["cryptography"] },
 ]
+pycryptodome = [
+    { name = "audible", extra = ["pycryptodome"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -90,6 +96,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "audible", specifier = ">=0.11.0" },
     { name = "audible", extras = ["cryptography"], marker = "extra == 'cryptography'", specifier = ">=0.11.0" },
+    { name = "audible", extras = ["pycryptodome"], marker = "extra == 'pycryptodome'", specifier = ">=0.11.0" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "colorama", marker = "sys_platform == 'win32'", specifier = ">=0.4.6" },
     { name = "httpx", specifier = ">=0.27.2,<0.29" },
@@ -100,7 +107,7 @@ requires-dist = [
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm", specifier = ">=4.69.0" },
 ]
-provides-extras = ["cryptography"]
+provides-extras = ["cryptography", "pycryptodome"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -480,6 +487,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The canonical download names now carry the architecture, and Linux and Windows gain arm64 builds beside the x86_64 ones. macOS was already Apple silicon only and stays that way.

### The names were the defect

Both macOS artifacts have been arm64 since the runner label moved under them, but `audible_mac.zip` says nothing about that — an Intel Mac downloads a file that cannot run and gets no hint why. Adding arm64 elsewhere would only have widened the same trap.

| Platform | canonical | retiring alias |
| --- | --- | --- |
| Linux 22.04 | `audible_linux_ubuntu_22_04_x86_64.zip` | `audible_linux_ubuntu_22_04.zip` |
| Linux 22.04 | `audible_linux_ubuntu_22_04_arm64.zip` | — |
| Linux 24.04 | `audible_linux_ubuntu_24_04_x86_64.zip` | `audible_linux_ubuntu_latest.zip` |
| Linux 24.04 | `audible_linux_ubuntu_24_04_arm64.zip` | — |
| macOS | `audible_mac_arm64.zip`, `…_dir.zip` | `audible_mac.zip`, `audible_mac_dir.zip` |
| Windows | `audible_win_x86_64.zip`, `…_dir.zip` | `audible_win.zip`, `audible_win_dir.zip` |
| Windows | `audible_win_arm64.zip`, `…_dir.zip` | — |

A `/releases/latest/download/<name>` link resolves the exact name it was given, so renaming breaks every link anyone copied. The six renamed artifacts are therefore published twice, under both names.

**Dropping the old names is a later change, not something this enforces.** The intent is after 15 November 2026 and not before two stable releases have carried both; the workflow keeps publishing them until someone removes the entries. Stated in the workflow, the README and the changelog.

### Windows arm64 uses a different crypto backend

`cryptography` publishes no `win_arm64` wheel, so that build uses `pycryptodome`. Both are accelerated — only the implementation differs — and PyInstaller's own `hook-Crypto.py` collects it without a `--collect-all`. A `pycryptodome` extra is added so the version resolves through `uv.lock` rather than being pulled in beside it. The README no longer claims every binary bundles `cryptography`.

### The x86_64 runner is pinned

`ubuntu-latest` became `ubuntu-24.04`, so it stays paired with `ubuntu-24.04-arm` instead of drifting the next time the label moves. The artifact follows the runner and says `24_04`; the old `…_latest.zip` carries on as one of the retiring aliases.

### Verification

Both new runners were exercised before the matrix was pointed at them, through a temporary `pull_request` job:

- `ubuntu-22.04-arm` reports `aarch64 Linux`, `windows-11-arm` reports `ARM64 Windows` with an arm64 CPython
- both produce a binary that starts
- both reach the config check in `activation-bytes`, so they got past provider selection, and **neither emits the legacy-crypto warning** — pycryptodome really is in use on Windows arm64

The full ten-entry matrix was then run the same way, twice: once before the pinning and once after. All ten jobs pass, `Create Release` and `Publish Release` skip, and `Also stage the retiring name` runs for exactly the six artifacts that have one and skips the four that do not. The temporary trigger has been removed; `build.yml` triggers on tag push and dispatch only, as before.

`fail-fast` is off. With ten entries, one broken runner hiding the state of the other nine is the opposite of useful.

### Note for later

`ubuntu-22.04` and `ubuntu-22.04-arm` are deprecated on 17 September 2026 and removed on 17 April 2027. Keeping the lower glibc baseline past that needs a pinned container, which is its own change.