### PR TITLE
fix: accept the MP3 content type Audible sends for podcast episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- AAXC downloads of podcast episodes are no longer rejected solely because Audible labels the payload `audio/mp3`. That is not a registered media type and was not in the accepted list, so the download failed with "Wrong content type" after the file had already been fetched. The AAX path keeps its own, narrower list: it always writes a `.aax` file because the codec is part of the request, so accepting an MP3 there would store it under the wrong name
+- The content type is now compared by its media type, so parameters and casing no longer decide the outcome. A title that has to be fetched in parts is also recognised again when its `Content-Type` is capitalised, which sent it to the wrong branch and reported a type mismatch instead
+
 ### Added
 
 - Standalone builds for arm64 on Linux and Windows, alongside the existing x86_64 ones. macOS was already Apple silicon only and stays that way; on an Intel Mac install from PyPI instead

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -13,7 +13,13 @@ import questionary
 from audible.exceptions import NotFoundError
 from click import echo
 
-from ..constants import API_CHAPTER_TYPES, CLI_CHAPTER_TYPE_CONFIG, QUALITIES
+from ..constants import (
+    AAX_CONTENT_TYPES,
+    AAXC_CONTENT_TYPES,
+    API_CHAPTER_TYPES,
+    CLI_CHAPTER_TYPE_CONFIG,
+    QUALITIES,
+)
 from ..decorators import (
     bunch_size_option,
     end_date_option,
@@ -327,9 +333,7 @@ async def download_aax(
     dl = NewDownloader(
         source=url,
         client=client,
-        expected_types=[
-            "audio/aax", "audio/vnd.audible.aax", "audio/audible", "audio/mp4"
-        ]
+        expected_types=list(AAX_CONTENT_TYPES)
     )
     downloaded = await dl.run(target=filepath, force_reload=overwrite_existing)
 
@@ -469,10 +473,7 @@ async def download_aaxc(
     dl = NewDownloader(
         source=url,
         client=client,
-        expected_types=[
-            "audio/aax", "audio/vnd.audible.aax", "audio/mpeg", "audio/x-m4a",
-            "audio/audible", "audio/mp4"
-        ],
+        expected_types=list(AAXC_CONTENT_TYPES),
     )
     downloaded = await dl.run(target=filepath, force_reload=overwrite_existing)
 

--- a/src/audible_cli/constants.py
+++ b/src/audible_cli/constants.py
@@ -41,6 +41,33 @@ QUALITIES: tuple[str, ...] = tuple(QUALITY_TO_API)
 API_CHAPTER_TYPES: tuple[str, ...] = ("Flat", "Tree")
 CLI_CHAPTER_TYPE_CONFIG: str = "config"
 
+# What a finished audio download is allowed to have arrived as. The paths
+# differ on purpose: AAX always writes `.aax` because the codec is part of
+# the request, while AAXC takes its format from the license and writes
+# `.mp3` for MPEG.
+#
+# Asked for a title it cannot serve — a podcast episode, say — the AAX
+# service still answers 302, and behind it sits HTTP 200 with no
+# Content-Length and `File Assembly error: Invalid Audio Format.` as
+# `text/html`. Measured for every codec, `mp3` included. No other check
+# objects to that, so this list is the only thing between an error page and
+# a `.aax` file counted as a success.
+AAX_CONTENT_TYPES: tuple[str, ...] = (
+    "audio/aax",
+    "audio/vnd.audible.aax",
+    "audio/audible",
+    "audio/mp4",
+)
+
+# Audible announces the same MP3 episode as the registered `audio/mpeg` or
+# as the unregistered `audio/mp3`, so both have to be listed.
+AAXC_CONTENT_TYPES: tuple[str, ...] = (
+    *AAX_CONTENT_TYPES,
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/x-m4a",
+)
+
 AVAILABLE_MARKETPLACES = [
     market["country_code"] for market in LOCALE_TEMPLATES.values()
 ]

--- a/src/audible_cli/downloader.py
+++ b/src/audible_cli/downloader.py
@@ -223,6 +223,20 @@ async def check_status_code(
     return Status.Success
 
 
+def _media_type(content_type: str | None) -> str | None:
+    """Everything before the first semicolon, trimmed and lowercased.
+
+    Parameters and casing are the server's to choose, and `audio/mpeg` and
+    `Audio/MPEG; charset=binary` name the same thing, so comparing the
+    header as it arrived turns that into a rejected download. This does not
+    validate the syntax: an empty header and one that is only parameters
+    both come back empty, and a missing one stays None.
+    """
+    if content_type is None:
+        return None
+    return content_type.split(";")[0].strip().lower()
+
+
 async def check_content_type(
     response: ResponseInfo, target_file: File, tmp_file: File,
     expected_types: list[str], **kwargs: Any
@@ -230,7 +244,11 @@ async def check_content_type(
     if not expected_types:
         return Status.Success
 
-    if response.content_type not in expected_types:
+    accepted = {m for m in map(_media_type, expected_types) if m}
+    media_type = _media_type(response.content_type)
+    # A header that is absent or names nothing matches nothing, whatever a
+    # caller may have put in its list
+    if not media_type or media_type not in accepted:
         content = await tmp_file.read_text_content()
         logger.error(
             "Error downloading %s. Wrong content type. Expected type(s): %s; Got: %s; "
@@ -254,7 +272,7 @@ def _status_for_message(message: str) -> Status:
 async def check_status_for_message(
     response: ResponseInfo, tmp_file: File, **kwargs: Any
 ) -> Status:
-    if response.content_type and "text" in response.content_type:
+    if "text" in (_media_type(response.content_type) or ""):
         length = response.content_length or await tmp_file.get_size()
         if length <= MAX_FILE_READ_SIZE:
             message = await tmp_file.read_text_content()

--- a/tests/test_content_type_check.py
+++ b/tests/test_content_type_check.py
@@ -1,0 +1,171 @@
+"""What a finished download is allowed to have arrived as.
+
+The check guards against a response that is not the audio that was asked
+for — an error page, or the note that a title has to be fetched in parts.
+It reads the header only, so it cannot vouch for the body.
+
+The two download paths keep separate lists on purpose: an AAX download
+always writes a `.aax` file, while an AAXC download names the file after
+its codec and writes `.mp3` for MPEG. Accepting an MP3 payload on the AAX
+path would store it under the wrong extension.
+"""
+
+import ast
+import asyncio
+import inspect
+
+import pytest
+
+from audible_cli.cmds import cmd_download
+from audible_cli.constants import AAX_CONTENT_TYPES, AAXC_CONTENT_TYPES
+from audible_cli.downloader import (
+    File,
+    ResponseInfo,
+    Status,
+    check_content_type,
+    check_status_for_message,
+)
+
+
+class Response:
+    def __init__(self, content_type):
+        self.headers = {} if content_type is None else {"Content-Type": content_type}
+        self.status_code = 200
+
+
+def check(tmp_path, content_type, expected):
+    tmp_file = File(tmp_path / "book.tmp")
+    tmp_file.path.write_bytes(b"audio")
+    return asyncio.run(
+        check_content_type(
+            response=ResponseInfo(Response(content_type)),
+            target_file=File(tmp_path / "book"),
+            tmp_file=tmp_file,
+            expected_types=list(expected),
+        )
+    )
+
+
+# Spelled out rather than derived from the constants: a list that generates
+# its own expectations shrinks along with the thing it is meant to guard.
+AAX_ACCEPTS = ["audio/aax", "audio/vnd.audible.aax", "audio/audible", "audio/mp4"]
+AAXC_ALSO_ACCEPTS = ["audio/mpeg", "audio/mp3", "audio/x-m4a"]
+
+
+def test_the_two_paths_expect_what_they_are_documented_to_expect():
+    assert list(AAX_CONTENT_TYPES) == AAX_ACCEPTS
+    assert list(AAXC_CONTENT_TYPES) == AAX_ACCEPTS + AAXC_ALSO_ACCEPTS
+
+
+@pytest.mark.parametrize("content_type", AAX_ACCEPTS)
+def test_both_paths_take_the_aax_family(tmp_path, content_type):
+    assert check(tmp_path, content_type, AAX_CONTENT_TYPES) is Status.Success
+    assert check(tmp_path, content_type, AAXC_CONTENT_TYPES) is Status.Success
+
+
+@pytest.mark.parametrize("content_type", AAXC_ALSO_ACCEPTS)
+def test_only_the_aaxc_path_takes_mp3_and_m4a(tmp_path, content_type):
+    # The AAXC path names the file after the codec and writes `.mp3` for
+    # MPEG; the AAX path would file the same bytes as `.aax`.
+    assert check(tmp_path, content_type, AAXC_CONTENT_TYPES) is Status.Success
+    assert (
+        check(tmp_path, content_type, AAX_CONTENT_TYPES)
+        is Status.DownloadContentTypeMismatch
+    )
+
+
+def test_the_unregistered_mp3_type_is_accepted(tmp_path):
+    # Audible sends `audio/mp3` for podcast episodes, not only the
+    # registered `audio/mpeg`, and seven downloads were rejected over it.
+    assert check(tmp_path, "audio/mp3", AAXC_CONTENT_TYPES) is Status.Success
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "AUDIO/MP3",  # casing is the server's choice
+        "audio/mpeg; charset=binary",  # so are parameters
+        "  audio/mp4  ",
+        "Audio/X-M4A ;q=1",
+    ],
+)
+def test_the_header_is_compared_by_its_media_type(tmp_path, header):
+    assert check(tmp_path, header, AAXC_CONTENT_TYPES) is Status.Success
+
+
+@pytest.mark.parametrize(
+    "content_type", ["text/html", "application/json", "text/plain"]
+)
+def test_something_that_is_not_audio_is_rejected(tmp_path, content_type):
+    assert (
+        check(tmp_path, content_type, AAXC_CONTENT_TYPES)
+        is Status.DownloadContentTypeMismatch
+    )
+
+
+@pytest.mark.parametrize("header", [None, "", "   ", "; charset=binary"])
+def test_a_header_that_names_nothing_is_rejected(tmp_path, header):
+    # Normalising both sides must not make an empty header match an empty
+    # entry somebody left in the list.
+    assert (
+        check(tmp_path, header, [*AAXC_CONTENT_TYPES, ""])
+        is Status.DownloadContentTypeMismatch
+    )
+
+
+def test_no_expectation_accepts_anything(tmp_path):
+    # Callers that pass no list are asking for no check at all
+    assert check(tmp_path, "text/html", []) is Status.Success
+
+
+@pytest.mark.parametrize(
+    "header", ["text/plain", "Text/Plain", "TEXT/PLAIN; charset=utf-8"]
+)
+def test_the_parts_message_is_found_whatever_the_header_looks_like(tmp_path, header):
+    # A title that has to be fetched in parts answers with a short text. The
+    # message check runs before the content type one and reads the body only
+    # for a text response, so a capitalised header sent it to the wrong
+    # branch and the caller was told the type was wrong instead.
+    tmp_file = File(tmp_path / "book.tmp")
+    tmp_file.path.write_text(
+        "Sorry, please download individual parts for this title.", encoding="utf-8"
+    )
+    status = asyncio.run(
+        check_status_for_message(
+            response=ResponseInfo(Response(header)), tmp_file=tmp_file
+        )
+    )
+
+    assert status is Status.DownloadIndividualParts
+
+
+def test_each_download_path_keeps_to_its_own_list():
+    """The AAX path must not start accepting what the AAXC path accepts.
+
+    An AAX download always writes `.aax` because the codec is part of the
+    request: `_get_codec` only ever returns an `aax_*` codec and the URL
+    call raises `NotDownloadableAsAAX` otherwise. The AAXC path takes its
+    format from the license instead and names the file after it, which is
+    why it alone accepts MP3 and M4A. Pointing the AAX call at the wider
+    list would file an MP3 under a `.aax` name.
+
+    Read from the syntax tree rather than the running functions: reaching
+    the `NewDownloader` call needs a license, a URL and a written voucher,
+    and stubbing all of that would test the stubs.
+    """
+    tree = ast.parse(inspect.getsource(cmd_download))
+    used = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            for keyword in call.keywords:
+                if keyword.arg == "expected_types":
+                    used[node.name] = ast.unparse(keyword.value)
+
+    assert used == {
+        "download_aax": "list(AAX_CONTENT_TYPES)",
+        "download_aaxc": "list(AAXC_CONTENT_TYPES)",
+    }, used


### PR DESCRIPTION
A podcast episode fetched with `--aaxc` arrives announced as `audio/mp3`. That is not a registered media type, it was not in the accepted list, and so seven episodes of a real download were rejected with **"Wrong content type"** after the bytes had already been fetched and written:

```
error: Error downloading …_Folge_716_….mp3. Wrong content type.
Expected type(s): ['audio/aax', 'audio/vnd.audible.aax', 'audio/mpeg',
'audio/x-m4a', 'audio/audible', 'audio/mp4']; Got: audio/mp3
```

## Why only the AAXC path gets it

The two paths keep separate lists, and they always have on purpose rather than by neglect. v0.1.0 introduced the MPEG branch that names an AAXC file `.mp3` and the `audio/mpeg`/`audio/x-m4a` entries in the same commit. The AAX path never had them because it always writes `.aax`, and it can: `_get_codec` only ever returns an `aax_*` codec and the URL call raises `NotDownloadableAsAAX` otherwise, so the format is part of the request rather than something the answer reports.

That was checked against the live service rather than assumed. Asked for a podcast episode the AAX endpoint cannot serve, it still answers `302`, and behind the redirect sits:

```
HTTP 200   Content-Type: text/html;charset=UTF-8   (no Content-Length)
File Assembly error: Invalid Audio Format.
```

Measured for every codec, including `mp3`, `MP3`, `mpeg` and `MPEG`. The status check, the size check and the parts-message check all pass that response; the content type check is the only one that rejects it. Adding `audio/mp3` to the AAX list would therefore file an error page as a `.aax` and count it as a success, so it goes to the AAXC list only. The finding is recorded as a comment on the constant.

## Also here

The comparison now looks at the bare media type. Parameters and casing are the server's to choose, and `Audio/MPEG; charset=binary` names the same thing as `audio/mpeg`. The same normalisation goes to the check for the "download individual parts" message, which reads the body only for a text response and missed a capitalised `Text/Plain`, reporting a type mismatch instead of the message the caller needs.

## Tests

`tests/test_content_type_check.py`, 150 tests green, Ruff clean. The expected sets are spelled out rather than derived from the constants, so a list that loses an entry fails instead of quietly testing less. Mutation-checked:

| reverted | result |
|---|---|
| `audio/mp3` removed | 4 failed |
| media-type normalisation removed | 4 failed |
| parts message made case-sensitive again | 2 failed |
| AAX call pointed at the wider list | 1 failed |
| unchanged | 150 passed |