### PR TITLE
fix: survive a dropped connection to Audible's CDE host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- A request to Audible's CDE host that never got an answer is made again, up to three times, with a growing and slightly randomised wait. Downloading a library with `-j 8` produced runs of `Server disconnected without sending a response.`, all of them on the annotations endpoint, and without `--ignore-errors` the first one ended the whole run. The endpoint is healthy when asked on its own, so the cause looks like a pooled connection the server had already closed while eight downloads were streaming through the same client. Only requests that got no answer at all are repeated: an HTTP status is an answer, and a 404 from the annotations endpoint is the ordinary way of saying a title has none
 - A failed download job now says which job it was. The message used to be the bare exception, so `Server disconnected without sending a response.` named neither the title nor the kind of file, and a run of several hundred jobs gave no way to tell which one to retry. It now reads `download_aaxc failed for <title> (<asin>): RemoteProtocolError: …`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- A failed download job now says which job it was. The message used to be the bare exception, so `Server disconnected without sending a response.` named neither the title nor the kind of file, and a run of several hundred jobs gave no way to tell which one to retry. It now reads `download_aaxc failed for <title> (<asin>): RemoteProtocolError: …`
+
 ### Fixed
 
 - AAXC downloads of podcast episodes are no longer rejected solely because Audible labels the payload `audio/mp3`. That is not a registered media type and was not in the accepted list, so the download failed with "Wrong content type" after the file had already been fetched. The AAX path keeps its own, narrower list: it always writes a `.aax` file because the codec is part of the request, so accepting an MP3 there would store it under the wrong name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- Repeat a request to Audible's CDE host that got no answer, up to three times with a growing, jittered wait. A dropped connection on the annotations endpoint used to end a whole `-j 8` run. Only requests without an answer are repeated; an HTTP status, 404 included, is left alone (#298)
-- A failed download job now names itself: the command, the title and the ASIN, instead of the bare exception (#298)
-
 ### Fixed
 
-- AAXC downloads of podcast episodes are no longer rejected solely because Audible labels the payload `audio/mp3`. That is not a registered media type and was not in the accepted list, so the download failed with "Wrong content type" after the file had already been fetched. The AAX path keeps its own, narrower list: it always writes a `.aax` file because the codec is part of the request, so accepting an MP3 there would store it under the wrong name
-- The content type is now compared by its media type, so parameters and casing no longer decide the outcome. A title that has to be fetched in parts is also recognised again when its `Content-Type` is capitalised, which sent it to the wrong branch and reported a type mismatch instead
+- Try a request to Audible's CDE host up to three times when it gets no answer, waiting a little longer each time. A dropped connection on the annotations endpoint used to end a whole `-j 8` run. An HTTP status is an answer and is never retried, 404 included (#298)
+- A failed download job now names itself: the command, the title and the ASIN, instead of the bare exception (#298)
+- AAXC downloads of podcast episodes are no longer rejected over the `audio/mp3` content type Audible sends for them. The AAX path keeps its own, narrower list: it always writes a `.aax` file, so accepting an MP3 there would misname it (#297)
+- The content type is compared by its media type, so parameters and casing no longer decide the outcome. That also brings back the "download individual parts" message, which a capitalised `Content-Type` had been hiding (#297)
 
 ### Added
 
-- Standalone builds for arm64 on Linux and Windows, alongside the existing x86_64 ones. macOS was already Apple silicon only and stays that way; on an Intel Mac install from PyPI instead
-- The download names now carry the architecture, for example `audible_win_x86_64.zip` and `audible_win_arm64.zip`. The Linux build that was named `latest` now names the Ubuntu release it is built on, 24.04, because the runner is pinned to it. The previous names are published alongside the new ones and will be dropped after 15 November 2026, so existing download links keep working until then
-- A `pycryptodome` extra, used by the Windows arm64 build because `cryptography` publishes no wheel for that platform. Both are accelerated; only the implementation differs
+- Standalone builds for arm64 on Linux and Windows, alongside the existing x86_64 ones. macOS stays Apple silicon only; on an Intel Mac install from PyPI (#296)
+- The download names now carry the architecture, for example `audible_win_arm64.zip`, and the Linux build names the Ubuntu release it is built on. The previous names are published alongside them until 15 November 2026 (#296)
+- A `pycryptodome` extra, used by the Windows arm64 build because `cryptography` publishes no wheel for that platform (#296)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- A request to Audible's CDE host that never got an answer is made again, up to three times, with a growing and slightly randomised wait. Downloading a library with `-j 8` produced runs of `Server disconnected without sending a response.`, all of them on the annotations endpoint, and without `--ignore-errors` the first one ended the whole run. The endpoint is healthy when asked on its own, so the cause looks like a pooled connection the server had already closed while eight downloads were streaming through the same client. Only requests that got no answer at all are repeated: an HTTP status is an answer, and a 404 from the annotations endpoint is the ordinary way of saying a title has none
-- A failed download job now says which job it was. The message used to be the bare exception, so `Server disconnected without sending a response.` named neither the title nor the kind of file, and a run of several hundred jobs gave no way to tell which one to retry. It now reads `download_aaxc failed for <title> (<asin>): RemoteProtocolError: …`
+- Repeat a request to Audible's CDE host that got no answer, up to three times with a growing, jittered wait. A dropped connection on the annotations endpoint used to end a whole `-j 8` run. Only requests without an answer are repeated; an HTTP status, 404 included, is left alone (#298)
+- A failed download job now names itself: the command, the title and the ASIN, instead of the bare exception (#298)
 
 ### Fixed
 

--- a/plugin_cmds/cmd_get-annotations.py
+++ b/plugin_cmds/cmd_get-annotations.py
@@ -1,7 +1,9 @@
 import click
 from audible.exceptions import NotFoundError
 
+from audible_cli.constants import CDE_ATTEMPTS, CDE_FIRST_DELAY
 from audible_cli.decorators import pass_client
+from audible_cli.utils import request_with_retry
 
 
 @click.command("get-annotations")
@@ -14,7 +16,12 @@ async def cli(client, asin):
         "key": asin
     }
     try:
-        r = await client.get(url, params=params)
+        r = await request_with_retry(
+            lambda: client.get(url, params=params),
+            f"The annotations for {asin}",
+            attempts=CDE_ATTEMPTS,
+            first_delay=CDE_FIRST_DELAY,
+        )
     except NotFoundError:
         click.echo(f"No annotations found for asin {asin}")
     else:

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -542,10 +542,8 @@ async def consume(run: DownloadRun):
 
             await cmd(**kwargs)
         except Exception as e:
-            # Say which job it was. On its own a message like "Server
-            # disconnected without sending a response" names neither the
-            # title nor the kind of file, and a run of hundreds of jobs
-            # gives no way to find out which one to retry.
+            # The bare exception names neither the title nor the kind of
+            # file, which leaves nothing to act on.
             item = kwargs.get("item")
             logger.error(
                 "%s failed for %s (%s): %s: %s",

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -542,7 +542,19 @@ async def consume(run: DownloadRun):
 
             await cmd(**kwargs)
         except Exception as e:
-            logger.error(e)
+            # Say which job it was. On its own a message like "Server
+            # disconnected without sending a response" names neither the
+            # title nor the kind of file, and a run of hundreds of jobs
+            # gives no way to find out which one to retry.
+            item = kwargs.get("item")
+            logger.error(
+                "%s failed for %s (%s): %s: %s",
+                cmd.__name__,
+                getattr(item, "full_title", "unknown title"),
+                getattr(item, "asin", "unknown asin"),
+                type(e).__name__,
+                e,
+            )
             run.record(e)
         finally:
             QUEUE.task_done()

--- a/src/audible_cli/constants.py
+++ b/src/audible_cli/constants.py
@@ -68,6 +68,11 @@ AAXC_CONTENT_TYPES: tuple[str, ...] = (
     "audio/x-m4a",
 )
 
+# The CDE host drops a connection now and then while downloads stream
+# through the same pool.
+CDE_ATTEMPTS: int = 3
+CDE_FIRST_DELAY: float = 0.5
+
 AVAILABLE_MARKETPLACES = [
     market["country_code"] for market in LOCALE_TEMPLATES.values()
 ]

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 import secrets
 import string
 import unicodedata
@@ -12,6 +13,7 @@ import audible
 import httpx
 from audible.aescipher import decrypt_voucher_from_licenserequest
 from audible.client import convert_response_content
+from audible.exceptions import NetworkError, NotResponding, RequestError, StatusError
 
 from .constants import (
     API_CHAPTER_TYPES,
@@ -36,6 +38,71 @@ from .utils import (
 
 
 logger = logging.getLogger("audible_cli.models")
+
+#: How often a request to the CDE host is made before giving up, and how
+#: long to wait after the first failure. The delay doubles and carries a
+#: little jitter, so eight workers that fail together do not come back
+#: together.
+CDE_ATTEMPTS = 3
+CDE_FIRST_DELAY = 0.5
+
+
+def is_transient(exc: BaseException) -> bool:
+    """Whether the request never got an answer and is worth repeating.
+
+    An answer, even an unwelcome one, is not transient: `StatusError` and
+    everything under it carries an HTTP status, and a 404 from the
+    annotations endpoint is the ordinary way of saying a title has none.
+
+    The audible client remaps httpx errors and raises `from None`, so the
+    original is not the cause but sits in `args`.
+    """
+    if isinstance(exc, httpx.TransportError):
+        # Raised straight at us, by a call that bypasses that client
+        return not isinstance(exc, httpx.LocalProtocolError)
+    if isinstance(exc, StatusError):
+        # Spelled out rather than relied on: a status error carries only its
+        # message, so it would fall through the check below anyway. This
+        # says what is meant if that ever changes.
+        return False
+    if isinstance(exc, NotResponding | NetworkError):
+        return True
+    if isinstance(exc, RequestError):
+        return any(
+            isinstance(arg, httpx.TransportError)
+            and not isinstance(arg, httpx.LocalProtocolError)
+            for arg in exc.args
+        )
+    return False
+
+
+async def request_with_retry(make_request, describe: str):
+    """Make an idempotent request, repeating it if it never got an answer.
+
+    Only for requests that can be repeated without consequence: the two CDE
+    calls read metadata and change nothing, so a second attempt after a
+    dropped connection cannot duplicate anything.
+    """
+    for attempt in range(1, CDE_ATTEMPTS + 1):
+        try:
+            return await make_request()
+        except Exception as exc:
+            if attempt == CDE_ATTEMPTS or not is_transient(exc):
+                raise
+            delay = CDE_FIRST_DELAY * 2 ** (attempt - 1)
+            delay *= random.uniform(0.8, 1.2)  # noqa: S311
+            logger.warning(
+                "%s got no answer (%s: %s). Attempt %s of %s, retrying in %.1fs.",
+                describe,
+                type(exc).__name__,
+                exc,
+                attempt,
+                CDE_ATTEMPTS,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    return None  # unreachable: the loop returns or raises
+
 
 
 def api_quality(quality: str) -> str:
@@ -319,7 +386,10 @@ class LibraryItem(BaseItem):
            "key": self.asin,
            "codec": codec_name
         }
-        r = await self._client.session.head(url, params=params)
+        r = await request_with_retry(
+            lambda: self._client.session.head(url, params=params),
+            f"The AAX download url for {self.asin}",
+        )
 
         try:
             link = r.headers["location"]
@@ -478,7 +548,10 @@ class LibraryItem(BaseItem):
             "key": self.asin
         }
 
-        annotations = await self._client.get(url, params=params)
+        annotations = await request_with_retry(
+            lambda: self._client.get(url, params=params),
+            f"The annotations for {self.asin}",
+        )
 
         return annotations
 

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import random
 import secrets
 import string
 import unicodedata
@@ -13,7 +12,6 @@ import audible
 import httpx
 from audible.aescipher import decrypt_voucher_from_licenserequest
 from audible.client import convert_response_content
-from audible.exceptions import NetworkError, NotResponding, RequestError, StatusError
 
 from .constants import (
     API_CHAPTER_TYPES,
@@ -33,76 +31,17 @@ from .utils import (
     LongestSubString,
     full_response_callback,
     parse_api_datetime,
+    request_with_retry,
     to_utc_datetime,
 )
 
 
 logger = logging.getLogger("audible_cli.models")
 
-#: How often a request to the CDE host is made before giving up, and how
-#: long to wait after the first failure. The delay doubles and carries a
-#: little jitter, so eight workers that fail together do not come back
-#: together.
+#: The CDE host drops a connection now and then while downloads stream
+#: through the same pool.
 CDE_ATTEMPTS = 3
 CDE_FIRST_DELAY = 0.5
-
-
-def is_transient(exc: BaseException) -> bool:
-    """Whether the request never got an answer and is worth repeating.
-
-    An answer, even an unwelcome one, is not transient: `StatusError` and
-    everything under it carries an HTTP status, and a 404 from the
-    annotations endpoint is the ordinary way of saying a title has none.
-
-    The audible client remaps httpx errors and raises `from None`, so the
-    original is not the cause but sits in `args`.
-    """
-    if isinstance(exc, httpx.TransportError):
-        # Raised straight at us, by a call that bypasses that client
-        return not isinstance(exc, httpx.LocalProtocolError)
-    if isinstance(exc, StatusError):
-        # Spelled out rather than relied on: a status error carries only its
-        # message, so it would fall through the check below anyway. This
-        # says what is meant if that ever changes.
-        return False
-    if isinstance(exc, NotResponding | NetworkError):
-        return True
-    if isinstance(exc, RequestError):
-        return any(
-            isinstance(arg, httpx.TransportError)
-            and not isinstance(arg, httpx.LocalProtocolError)
-            for arg in exc.args
-        )
-    return False
-
-
-async def request_with_retry(make_request, describe: str):
-    """Make an idempotent request, repeating it if it never got an answer.
-
-    Only for requests that can be repeated without consequence: the two CDE
-    calls read metadata and change nothing, so a second attempt after a
-    dropped connection cannot duplicate anything.
-    """
-    for attempt in range(1, CDE_ATTEMPTS + 1):
-        try:
-            return await make_request()
-        except Exception as exc:
-            if attempt == CDE_ATTEMPTS or not is_transient(exc):
-                raise
-            delay = CDE_FIRST_DELAY * 2 ** (attempt - 1)
-            delay *= random.uniform(0.8, 1.2)  # noqa: S311
-            logger.warning(
-                "%s got no answer (%s: %s). Attempt %s of %s, retrying in %.1fs.",
-                describe,
-                type(exc).__name__,
-                exc,
-                attempt,
-                CDE_ATTEMPTS,
-                delay,
-            )
-            await asyncio.sleep(delay)
-    return None  # unreachable: the loop returns or raises
-
 
 
 def api_quality(quality: str) -> str:
@@ -389,6 +328,8 @@ class LibraryItem(BaseItem):
         r = await request_with_retry(
             lambda: self._client.session.head(url, params=params),
             f"The AAX download url for {self.asin}",
+            attempts=CDE_ATTEMPTS,
+            first_delay=CDE_FIRST_DELAY,
         )
 
         try:
@@ -551,6 +492,8 @@ class LibraryItem(BaseItem):
         annotations = await request_with_retry(
             lambda: self._client.get(url, params=params),
             f"The annotations for {self.asin}",
+            attempts=CDE_ATTEMPTS,
+            first_delay=CDE_FIRST_DELAY,
         )
 
         return annotations

--- a/src/audible_cli/models.py
+++ b/src/audible_cli/models.py
@@ -15,6 +15,8 @@ from audible.client import convert_response_content
 
 from .constants import (
     API_CHAPTER_TYPES,
+    CDE_ATTEMPTS,
+    CDE_FIRST_DELAY,
     CODEC_HIGH_QUALITY,
     CODEC_NORMAL_QUALITY,
     QUALITIES,
@@ -37,12 +39,6 @@ from .utils import (
 
 
 logger = logging.getLogger("audible_cli.models")
-
-#: The CDE host drops a connection now and then while downloads stream
-#: through the same pool.
-CDE_ATTEMPTS = 3
-CDE_FIRST_DELAY = 0.5
-
 
 def api_quality(quality: str) -> str:
     """Return what a request sends for this `--quality` value.

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -1,7 +1,9 @@
+import asyncio
 import csv
 import io
 import logging
 import pathlib
+import random
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
 
@@ -11,6 +13,12 @@ import httpx
 import tqdm
 from audible import Authenticator
 from audible.client import raise_for_status
+from audible.exceptions import (
+    NetworkError,
+    NotResponding,
+    RequestError,
+    StatusError,
+)
 from audible.login import default_login_url_callback
 from click import echo, prompt, secho
 from PIL import Image
@@ -19,6 +27,57 @@ from .constants import DEFAULT_AUTH_FILE_ENCRYPTION
 
 
 logger = logging.getLogger("audible_cli.utils")
+
+
+def is_transient(exc: BaseException) -> bool:
+    """Whether a request never got an answer and is worth repeating.
+
+    An answer is not transient, however unwelcome: every `StatusError`
+    carries an HTTP status. The audible client remaps httpx errors and
+    raises `from None`, so the original sits in `args`, not in the cause.
+    """
+    if isinstance(exc, httpx.TransportError):
+        return not isinstance(exc, httpx.LocalProtocolError)
+    if isinstance(exc, StatusError):
+        return False
+    if isinstance(exc, NotResponding | NetworkError):
+        return True
+    if isinstance(exc, RequestError):
+        return any(
+            isinstance(arg, httpx.TransportError)
+            and not isinstance(arg, httpx.LocalProtocolError)
+            for arg in exc.args
+        )
+    return False
+
+
+async def request_with_retry(
+    make_request, describe: str, *, attempts: int = 3, first_delay: float = 0.5
+):
+    """Make a request again while it gets no answer at all.
+
+    Only for requests that can be repeated without consequence. The delay
+    doubles and carries jitter, so callers that fail together do not return
+    together.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return await make_request()
+        except Exception as exc:
+            if attempt == attempts or not is_transient(exc):
+                raise
+            delay = first_delay * 2 ** (attempt - 1) * random.uniform(0.8, 1.2)  # noqa: S311
+            logger.warning(
+                "%s got no answer (%s: %s). Attempt %s of %s, retrying in %.1fs.",
+                describe,
+                type(exc).__name__,
+                exc,
+                attempt,
+                attempts,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    return None  # unreachable: the loop returns or raises
 
 
 def to_utc_datetime(value: datetime) -> datetime:

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -32,9 +32,9 @@ logger = logging.getLogger("audible_cli.utils")
 def is_transient(exc: BaseException) -> bool:
     """Whether a request never got an answer and is worth repeating.
 
-    An answer is not transient, however unwelcome: every `StatusError`
-    carries an HTTP status. The audible client remaps httpx errors and
-    raises `from None`, so the original sits in `args`, not in the cause.
+    An answer is not transient: every `StatusError` carries an HTTP status.
+    The audible client remaps httpx errors and raises `from None`, so the
+    original sits in `args`, not in the cause.
     """
     if isinstance(exc, httpx.TransportError):
         return not isinstance(exc, httpx.LocalProtocolError)
@@ -52,14 +52,18 @@ def is_transient(exc: BaseException) -> bool:
 
 
 async def request_with_retry(
-    make_request, describe: str, *, attempts: int = 3, first_delay: float = 0.5
+    make_request, describe: str, *, attempts: int, first_delay: float
 ):
     """Make a request again while it gets no answer at all.
 
-    Only for requests that can be repeated without consequence. The delay
-    doubles and carries jitter, so callers that fail together do not return
-    together.
+    Only for requests that can be repeated without consequence. How many
+    times and how long to wait are the caller's to decide: `attempts` counts
+    the total, and the delay starts at `first_delay` seconds, doubles, and
+    carries jitter so callers that fail together do not retry together.
     """
+    if attempts < 1:
+        raise ValueError(f"attempts must be at least 1, not {attempts}")
+
     for attempt in range(1, attempts + 1):
         try:
             return await make_request()

--- a/tests/test_cde_retry.py
+++ b/tests/test_cde_retry.py
@@ -1,20 +1,14 @@
 """Repeating a CDE request that never got an answer.
 
-Downloading a library with `-j 8` produced a run of failures, all of them
-`download_annotations`, all reading `RequestError: Server disconnected
-without sending a response.` Without `--ignore-errors` the first one ends
-the whole run.
-
-The endpoint itself is healthy: asked on its own it answers a clean 404 for
-every title, sequentially and at eight at a time. The failure needs the rest
-of the run, eight concurrent streaming downloads sharing one connection
-pool, which is what a reused connection the server has already closed looks
-like from httpx.
+Downloading with `-j 8` produced runs of `Server disconnected without
+sending a response.`, always on the annotations endpoint, and without
+`--ignore-errors` the first one ends the run.
 """
 
 import ast
 import asyncio
 import inspect
+import random
 
 import httpx
 import pytest
@@ -27,7 +21,6 @@ from audible.exceptions import (
 )
 
 from audible_cli import models
-from audible_cli.models import CDE_ATTEMPTS
 from audible_cli.utils import is_transient, request_with_retry
 
 
@@ -79,8 +72,13 @@ def no_waiting(monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", at_once)
 
 
-def run(make_request):
-    return asyncio.run(request_with_retry(make_request, "A request"))
+ATTEMPTS = 3
+
+
+def run(make_request, **policy):
+    policy.setdefault("attempts", ATTEMPTS)
+    policy.setdefault("first_delay", 0.5)
+    return asyncio.run(request_with_retry(make_request, "A request", **policy))
 
 
 # --- what counts as worth repeating ---------------------------------------
@@ -128,12 +126,12 @@ def test_a_status_error_is_never_transient_although_it_is_a_request_error():
 
 
 def test_it_gives_up_after_the_last_attempt():
-    always = Answering(disconnected(), failures=CDE_ATTEMPTS)
+    always = Answering(disconnected(), failures=ATTEMPTS)
 
     with pytest.raises(RequestError):
         run(always)
 
-    assert always.calls == CDE_ATTEMPTS
+    assert always.calls == ATTEMPTS
 
 
 def test_it_returns_the_answer_once_one_arrives():
@@ -154,15 +152,21 @@ def test_an_answer_ends_it_at_once():
     assert once.calls == 1
 
 
-def test_a_first_attempt_that_works_is_not_slowed_down():
+def test_a_first_attempt_that_works_is_not_slowed_down(monkeypatch):
+    waits = []
+
+    async def record(seconds):
+        waits.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", record)
     straight = Answering(disconnected(), failures=0)
 
     assert run(straight) == "the answer"
     assert straight.calls == 1
+    assert waits == [], "nothing to wait for"
 
 
-def test_the_wait_grows_and_is_not_the_same_for_everyone(monkeypatch):
-    # Eight workers that fail together must not come back together.
+def test_the_wait_grows(monkeypatch):
     waits = []
 
     async def record(seconds):
@@ -170,11 +174,31 @@ def test_the_wait_grows_and_is_not_the_same_for_everyone(monkeypatch):
 
     monkeypatch.setattr(asyncio, "sleep", record)
     with pytest.raises(RequestError):
-        run(Answering(disconnected(), failures=CDE_ATTEMPTS))
+        run(Answering(disconnected(), failures=ATTEMPTS))
 
-    assert len(waits) == CDE_ATTEMPTS - 1, "no wait after the last attempt"
-    assert waits[1] > waits[0], "the wait grows"
-    assert not any(w in (0.5, 1.0) for w in waits), "and carries jitter"
+    assert len(waits) == ATTEMPTS - 1, "no wait after the last attempt"
+    assert 0.4 <= waits[0] <= 0.6, waits
+    assert 0.8 <= waits[1] <= 1.2, waits
+
+
+def test_two_workers_that_fail_together_do_not_retry_together(monkeypatch):
+    # Otherwise eight of them come back in lockstep, at the moment the host
+    # is least able to answer.
+    # What `random.uniform` would hand two workers that fail at the same
+    # moment: the low end of the range for one, the high end for the other.
+    jitter = iter([0.8, 0.8, 1.2, 1.2])
+    monkeypatch.setattr(random, "uniform", lambda a, b: next(jitter))
+    waits = []
+
+    async def record(seconds):
+        waits.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", record)
+    for _ in range(2):
+        with pytest.raises(RequestError):
+            run(Answering(disconnected(), failures=ATTEMPTS))
+
+    assert waits[0] != waits[2], f"both workers waited {waits[0]}"
 
 
 def test_it_says_so_when_it_repeats(caplog, monkeypatch):
@@ -183,11 +207,17 @@ def test_it_says_so_when_it_repeats(caplog, monkeypatch):
         pass
 
     monkeypatch.setattr(asyncio, "sleep", nowait)
-    with caplog.at_level("WARNING", logger="audible_cli.models"):
-        run(Answering(disconnected(), failures=1))
+    twice = Answering(disconnected(), failures=1)
+    with caplog.at_level("WARNING", logger="audible_cli.utils"):
+        run(twice)
 
-    assert "Server disconnected" in caplog.text
-    assert "RequestError" in caplog.text
+    assert twice.calls == 2, "it says so because it did so"
+    warned = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert [r.name for r in warned] == ["audible_cli.utils"], (
+        "anyone filtering on this logger has to be able to find it"
+    )
+    assert "Server disconnected" in warned[0].getMessage()
+    assert "retrying" in warned[0].getMessage()
 
 
 def test_both_cde_requests_go_through_the_retry():
@@ -218,9 +248,7 @@ def test_the_caller_decides_how_often_and_how_long():
     # The helper is generic; the numbers are the caller's policy.
     stubborn = Answering(disconnected(), failures=4)
 
-    assert asyncio.run(request_with_retry(stubborn, "A request", attempts=5)) == (
-        "the answer"
-    )
+    assert run(stubborn, attempts=5) == "the answer"
     assert stubborn.calls == 5
 
 
@@ -232,13 +260,6 @@ def test_the_first_delay_is_the_callers_too(monkeypatch):
 
     monkeypatch.setattr(asyncio, "sleep", record)
     with pytest.raises(RequestError):
-        asyncio.run(
-            request_with_retry(
-                Answering(disconnected(), failures=3),
-                "A request",
-                attempts=3,
-                first_delay=10,
-            )
-        )
+        run(Answering(disconnected(), failures=3), first_delay=10)
 
     assert waits[0] > 5, waits

--- a/tests/test_cde_retry.py
+++ b/tests/test_cde_retry.py
@@ -1,0 +1,213 @@
+"""Repeating a CDE request that never got an answer.
+
+Downloading a library with `-j 8` produced a run of failures, all of them
+`download_annotations`, all reading `RequestError: Server disconnected
+without sending a response.` Without `--ignore-errors` the first one ends
+the whole run.
+
+The endpoint itself is healthy: asked on its own it answers a clean 404 for
+every title, sequentially and at eight at a time. The failure needs the rest
+of the run, eight concurrent streaming downloads sharing one connection
+pool, which is what a reused connection the server has already closed looks
+like from httpx.
+"""
+
+import ast
+import asyncio
+import inspect
+
+import httpx
+import pytest
+from audible.exceptions import (
+    NetworkError,
+    NotFoundError,
+    NotResponding,
+    RequestError,
+    Unauthorized,
+)
+
+from audible_cli import models
+from audible_cli.models import CDE_ATTEMPTS, is_transient, request_with_retry
+
+
+class Answered:
+    """Enough of a response for the library's status errors to build."""
+
+    def __init__(self, status_code, reason_phrase="Not Found"):
+        self.status_code = status_code
+        self.reason_phrase = reason_phrase
+
+
+def not_found():
+    return NotFoundError(Answered(404), None)
+
+
+def disconnected():
+    """What the audible client turns a dropped connection into."""
+    return RequestError(
+        httpx.RemoteProtocolError("Server disconnected without sending a response.")
+    )
+
+
+class Answering:
+    """Fails the first `failures` calls, then answers."""
+
+    def __init__(self, error, failures):
+        self.error = error
+        self.failures = failures
+        self.calls = 0
+
+    async def __call__(self):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.error
+        return "the answer"
+
+
+@pytest.fixture(autouse=True)
+def no_waiting(monkeypatch):
+    """Nobody waits in a test run.
+
+    The two tests about the wait itself replace this with their own
+    recorder.
+    """
+
+    async def at_once(seconds):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", at_once)
+
+
+def run(make_request):
+    return asyncio.run(request_with_retry(make_request, "A request"))
+
+
+# --- what counts as worth repeating ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        disconnected(),
+        RequestError(httpx.ReadError("connection reset")),
+        NetworkError(),
+        NotResponding(),
+        httpx.RemoteProtocolError("raised straight at us"),
+        httpx.ConnectTimeout("no answer"),
+    ],
+)
+def test_a_request_that_got_no_answer_is_repeated(error):
+    assert is_transient(error), f"{type(error).__name__} should be retried"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        not_found(),  # the ordinary "this title has none"
+        Unauthorized(
+            Answered(401, "Unauthorized"), None
+        ),  # will not heal by asking again
+        httpx.LocalProtocolError("our own mistake"),
+        ValueError("nothing to do with the network"),
+    ],
+)
+def test_an_answer_is_not_repeated(error):
+    assert not is_transient(error), f"{type(error).__name__} should not be retried"
+
+
+def test_a_status_error_is_never_transient_although_it_is_a_request_error():
+    # The trap: every StatusError is a RequestError too, so catching the
+    # base class would repeat every 404 — and for annotations a 404 is the
+    # normal answer for a title nobody has bookmarked.
+    assert issubclass(NotFoundError, RequestError)
+    assert not is_transient(not_found())
+
+
+# --- and what the helper does with it -------------------------------------
+
+
+def test_it_gives_up_after_the_last_attempt():
+    always = Answering(disconnected(), failures=CDE_ATTEMPTS)
+
+    with pytest.raises(RequestError):
+        run(always)
+
+    assert always.calls == CDE_ATTEMPTS
+
+
+def test_it_returns_the_answer_once_one_arrives():
+    twice = Answering(disconnected(), failures=2)
+
+    assert run(twice) == "the answer"
+    assert twice.calls == 3
+
+
+def test_an_answer_ends_it_at_once():
+    # A 404 is an answer. Asking again would be pointless traffic against a
+    # host that is already being asked by eight workers.
+    once = Answering(not_found(), failures=1)
+
+    with pytest.raises(NotFoundError):
+        run(once)
+
+    assert once.calls == 1
+
+
+def test_a_first_attempt_that_works_is_not_slowed_down():
+    straight = Answering(disconnected(), failures=0)
+
+    assert run(straight) == "the answer"
+    assert straight.calls == 1
+
+
+def test_the_wait_grows_and_is_not_the_same_for_everyone(monkeypatch):
+    # Eight workers that fail together must not come back together.
+    waits = []
+
+    async def record(seconds):
+        waits.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", record)
+    with pytest.raises(RequestError):
+        run(Answering(disconnected(), failures=CDE_ATTEMPTS))
+
+    assert len(waits) == CDE_ATTEMPTS - 1, "no wait after the last attempt"
+    assert waits[1] > waits[0], "the wait grows"
+    assert not any(w in (0.5, 1.0) for w in waits), "and carries jitter"
+
+
+def test_it_says_so_when_it_repeats(caplog, monkeypatch):
+    # A silent retry hides an outage that is getting worse.
+    async def nowait(seconds):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", nowait)
+    with caplog.at_level("WARNING", logger="audible_cli.models"):
+        run(Answering(disconnected(), failures=1))
+
+    assert "Server disconnected" in caplog.text
+    assert "RequestError" in caplog.text
+
+
+def test_both_cde_requests_go_through_the_retry():
+    """The two calls to the CDE host, and only those, are repeated.
+
+    Read from the syntax tree: reaching either one for real needs an
+    authenticated client and the network, and a call that quietly bypasses
+    the helper looks identical until a connection drops in production.
+    """
+    tree = ast.parse(inspect.getsource(models))
+    cde_methods = set()
+    wrapped = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        body = ast.unparse(node)
+        if "FionaCDEServiceEngine" not in body:
+            continue
+        cde_methods.add(node.name)
+        if "request_with_retry" in body:
+            wrapped.add(node.name)
+
+    assert cde_methods == {"get_annotations", "get_aax_url_old"}, cde_methods
+    assert wrapped == cde_methods, f"not repeated: {cde_methods - wrapped}"

--- a/tests/test_cde_retry.py
+++ b/tests/test_cde_retry.py
@@ -27,7 +27,8 @@ from audible.exceptions import (
 )
 
 from audible_cli import models
-from audible_cli.models import CDE_ATTEMPTS, is_transient, request_with_retry
+from audible_cli.models import CDE_ATTEMPTS
+from audible_cli.utils import is_transient, request_with_retry
 
 
 class Answered:
@@ -211,3 +212,33 @@ def test_both_cde_requests_go_through_the_retry():
 
     assert cde_methods == {"get_annotations", "get_aax_url_old"}, cde_methods
     assert wrapped == cde_methods, f"not repeated: {cde_methods - wrapped}"
+
+
+def test_the_caller_decides_how_often_and_how_long():
+    # The helper is generic; the numbers are the caller's policy.
+    stubborn = Answering(disconnected(), failures=4)
+
+    assert asyncio.run(request_with_retry(stubborn, "A request", attempts=5)) == (
+        "the answer"
+    )
+    assert stubborn.calls == 5
+
+
+def test_the_first_delay_is_the_callers_too(monkeypatch):
+    waits = []
+
+    async def record(seconds):
+        waits.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", record)
+    with pytest.raises(RequestError):
+        asyncio.run(
+            request_with_retry(
+                Answering(disconnected(), failures=3),
+                "A request",
+                attempts=3,
+                first_delay=10,
+            )
+        )
+
+    assert waits[0] > 5, waits

--- a/tests/test_cde_retry.py
+++ b/tests/test_cde_retry.py
@@ -8,6 +8,7 @@ sending a response.`, always on the annotations endpoint, and without
 import ast
 import asyncio
 import inspect
+import pathlib
 import random
 
 import httpx
@@ -242,6 +243,15 @@ def test_both_cde_requests_go_through_the_retry():
 
     assert cde_methods == {"get_annotations", "get_aax_url_old"}, cde_methods
     assert wrapped == cde_methods, f"not repeated: {cde_methods - wrapped}"
+
+
+def test_the_bundled_plugin_asks_the_same_way():
+    # It talks to the same host with its own request rather than through a
+    # model, so it needs the same treatment.
+    source = pathlib.Path("plugin_cmds/cmd_get-annotations.py").read_text()
+
+    assert "FionaCDEServiceEngine" in source, "the plugin this is about"
+    assert "request_with_retry(" in source
 
 
 def test_the_caller_decides_how_often_and_how_long():

--- a/tests/test_download_queue.py
+++ b/tests/test_download_queue.py
@@ -210,5 +210,6 @@ def test_a_failure_says_which_job_it_was(caplog):
     line = caplog.text
     assert "disconnects" in line, "which kind of job"
     assert "B0FQJHTG19" in line, "which title, by asin"
+    assert "Die Hand von Thrawn" in line, "and by name"
     assert "RemoteProtocolError" in line, "and what actually went wrong"
     assert "Server disconnected" in line

--- a/tests/test_download_queue.py
+++ b/tests/test_download_queue.py
@@ -5,7 +5,9 @@ and QUEUE.join() then waited forever, and the exit code from #256.
 """
 
 import asyncio
+import logging
 
+import httpx
 import pytest
 
 from audible_cli.cmds import cmd_download
@@ -178,3 +180,35 @@ def test_drain_queue_completes_a_normal_run():
     run = asyncio.run(main())
 
     assert (run.errors, run.skipped) == ([], 0)
+
+
+class NamedItem:
+    asin = "B0FQJHTG19"
+    full_title = "Star Wars: Die Hand von Thrawn"
+
+
+async def disconnects(item):
+    raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+
+def test_a_failure_says_which_job_it_was(caplog):
+    # "Server disconnected without sending a response" on its own names
+    # neither the title nor the kind of file, and a run of hundreds of jobs
+    # gives no way to find out which one to retry.
+    async def main():
+        cmd_download.QUEUE = asyncio.Queue()
+        run = DownloadRun(ignore_errors=True)
+        cmd_download.QUEUE.put_nowait((disconnects, {"item": NamedItem()}))
+        consumer = asyncio.create_task(consume(run))
+        await asyncio.wait_for(cmd_download.QUEUE.join(), timeout=5)
+        consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+
+    with caplog.at_level(logging.ERROR, logger="audible_cli.cmds.cmd_download"):
+        asyncio.run(main())
+
+    line = caplog.text
+    assert "disconnects" in line, "which kind of job"
+    assert "B0FQJHTG19" in line, "which title, by asin"
+    assert "RemoteProtocolError" in line, "and what actually went wrong"
+    assert "Server disconnected" in line


### PR DESCRIPTION
Downloading a library with `-j 8` produced runs of failures like this, and without `--ignore-errors` the first one ends a run of thousands of jobs:

```
error: Server disconnected without sending a response.
```

Two commits: the first makes that message say what it was, the second stops it ending the run.

## Saying which job failed

A job that raised was logged as the bare exception, which named neither the title nor the kind of file. The identity was there all along — `cmd` is the download function and every queued job carries its `item` — it was just thrown away. The line now reads:

```
error: download_annotations failed for Sternengeschichten Folge 699 …
(B0GXJ7Y275): RequestError: Server disconnected without sending a response.
```

That is what turned an untraceable message into a diagnosis: **every** failure was `download_annotations`.

## Asking again

The annotations endpoint is healthy when asked on its own — a clean 404 for every title tried, sequentially and at eight at a time, thirty-two requests without a drop. Nobody has annotations, and the code already reads that 404 as "none". The failure needs the rest of the run: eight concurrent streaming downloads sharing one connection pool, which is what a reused connection the server has already closed looks like from httpx.

That last step is a hypothesis; it was not reproduced in isolation. The remedy does not depend on it, because a request that never got an answer is worth making again whatever dropped it.

Both calls to that host — the annotations sidecar and the AAX download url — now go through one helper: three attempts, half a second before the second and twice that before the third, each with jitter so eight workers that fail together do not return together. Every repeat is logged at warning level, because a silent one hides an outage that is getting worse.

Confirmed in a real run:

```
warning: The annotations for B0DCPYNJ1Y got no answer (RequestError: Server
disconnected without sending a response.). Attempt 1 of 3, retrying in 0.5s.
```

No second attempt for that title, and no failure.

## Only what got no answer

An HTTP status *is* an answer. `StatusError` and everything under it stays as it is, which matters most for the 404 that means a title has no annotations. Two traps sit here:

- The audible client remaps httpx errors and raises `from None`, so the original is not the cause but sits in `args`.
- Every `StatusError` is a `RequestError` too, so catching the base class would have repeated every one of those 404s.

## Deliberately not done

- Retrying whole jobs — a failed sidecar request would re-stream hundreds of megabytes.
- Retrying at the transport — it would cover the license `POST` and mid-stream failures.
- Treating a dropped connection as "no annotations" — that silently loses real bookmarks. The sibling Rust implementation carries an audit note about exactly this mistake.
- Tuning the connection pool. Reachable via `@pass_client(limits=…)`, as `cmd_wishlist.py` does, but worth trying only if retrying turns out not to be enough.

## Tests

169 green, 17 new in `tests/test_cde_retry.py`, none touching the network. Mutation-checked:

| reverted | result |
|---|---|
| retry everything, not only transport failures | 1 failed |
| no jitter | 1 failed |
| no wait between attempts | 1 failed |
| AAX call no longer wrapped | 1 failed |
| unchanged | 169 passed |

A syntax-tree test requires that **every** method containing `FionaCDEServiceEngine` goes through the helper, so a third CDE call added later cannot quietly skip it.