### PR TITLE
fix: stop spending a voucher on a podcast episode already fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
 - A request to Audible's CDE host is tried up to three times when it gets no answer (#298)
 - A failed download job now names the command, the title and the ASIN (#298)

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -1,6 +1,7 @@
 import asyncio
 import asyncio.log
 import asyncio.sslproto
+import glob
 import json
 import logging
 import pathlib
@@ -411,6 +412,41 @@ async def _reuse_voucher(lr_file, item):
     return lr, url, codec
 
 
+def _finished_downloads(output_dir, base_filename, item, quality):
+    """What an earlier attempt at this title may have left behind.
+
+    Worth guessing because it saves a license request, and a license costs
+    a voucher whether or not anything is found. `_get_codec` knows the AAXC
+    name up front, but a podcast episode has no codec until its license
+    arrives, so every run used to buy one for an episode already on disk.
+    A voucher counts as a find: a download that died after writing it can
+    reuse that license.
+    """
+    folder = pathlib.Path(output_dir)
+    codec, _ = item._get_codec(quality)
+    if codec is not None:
+        yield folder / f"{base_filename}-{codec}.aaxc"
+        return
+
+    # The name is `<title>-<format>` and a format carries no hyphen, so the
+    # last one separates them. A wildcard cannot say "exactly one segment"
+    # and would let `Foo` claim `Foo-Bar-MPEG.mp3`, so both halves are
+    # compared, the format in whatever casing Audible used. The title is
+    # escaped because brackets in it would read as a character class.
+    seen = set()
+    escaped = glob.escape(base_filename)
+    for found in sorted(folder.glob(f"{escaped}-*.mp3")) + sorted(
+        folder.glob(f"{escaped}-*.voucher")
+    ):
+        title, _, content_format = found.stem.rpartition("-")
+        if title != base_filename or content_format.lower() != "mpeg":
+            continue
+        candidate = found.with_suffix(".mp3")
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+
+
 async def download_aaxc(
     client, output_dir, base_filename, item, quality, overwrite_existing,
     filename_mode, filename_length
@@ -419,10 +455,7 @@ async def download_aaxc(
 
     # https://github.com/mkb79/audible-cli/issues/60
     if not overwrite_existing:
-        codec, _ = item._get_codec(quality)
-        if codec is not None:
-            filepath = pathlib.Path(
-                output_dir) / f"{base_filename}-{codec}.aaxc"
+        for filepath in _finished_downloads(output_dir, base_filename, item, quality):
             lr_file = filepath.with_suffix(".voucher")
 
             if lr_file.is_file():
@@ -445,6 +478,7 @@ async def download_aaxc(
                         lr_file
                     )
                     overwrite_existing = True
+                break
 
     is_aycl = item.benefit_id == "AYCL"
 

--- a/tests/test_finished_downloads.py
+++ b/tests/test_finished_downloads.py
@@ -1,0 +1,137 @@
+"""Finding a download that is already on disk, before asking for a license.
+
+A license costs a voucher whether or not the file turns out to be there, so
+the download command guesses the name up front and skips the request when it
+finds both the file and its voucher.
+
+That guess only ever worked for AAXC. A podcast episode has no `aax_*`
+codec, so `_get_codec` returns nothing, and its real name is not knowable
+until the license says MPEG. Every run therefore spent a voucher on an
+episode that had been downloaded long ago.
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+from audible_cli.cmds import cmd_download
+from audible_cli.cmds.cmd_download import _finished_downloads
+
+
+class Item:
+    """An item whose codec is whatever the test says it is."""
+
+    def __init__(self, codec):
+        self._codec = codec
+
+    def _get_codec(self, quality):
+        return self._codec, "enhanced"
+
+
+def found(folder, item):
+    return [p.name for p in _finished_downloads(folder, "a-title", item, "best")]
+
+
+def test_an_audiobook_is_looked_for_by_the_codec_the_library_knows(tmp_path):
+    # Nothing has to exist for this one: the name follows from the codec, so
+    # the guess is exact and needs no directory listing.
+    assert found(tmp_path, Item("AAX_44_128")) == ["a-title-AAX_44_128.aaxc"]
+
+
+def test_a_podcast_episode_is_looked_for_as_the_mp3_it_was_saved_as(tmp_path):
+    (tmp_path / "a-title-MPEG.mp3").touch()
+
+    assert found(tmp_path, Item(None)) == ["a-title-MPEG.mp3"]
+
+
+def test_an_episode_that_is_not_there_yet_turns_up_nothing(tmp_path):
+    # Unlike the audiobook above, which is named rather than looked for
+    assert found(tmp_path, Item(None)) == []
+
+
+def test_a_voucher_left_by_a_failed_attempt_counts_as_a_find(tmp_path):
+    # The voucher is written before the audio is renamed into place, so a
+    # download that failed in between leaves one behind. Finding it lets
+    # the retry reuse that license instead of buying another.
+    (tmp_path / "a-title-MPEG.voucher").touch()
+
+    assert found(tmp_path, Item(None)) == ["a-title-MPEG.mp3"]
+
+
+def test_a_voucher_from_a_different_format_is_left_alone(tmp_path):
+    # Vouchers are looked for as well as audio, and one from an AAXC
+    # download names its own format. Taking it would offer an `.mp3` that
+    # was never written and hand its license to the wrong kind of file.
+    (tmp_path / "a-title-AAX_44_128.voucher").touch()
+
+    assert found(tmp_path, Item(None)) == []
+
+
+def test_a_title_is_offered_once_even_with_both_halves_on_disk(tmp_path):
+    (tmp_path / "a-title-MPEG.mp3").touch()
+    (tmp_path / "a-title-MPEG.voucher").touch()
+
+    assert found(tmp_path, Item(None)) == ["a-title-MPEG.mp3"]
+
+
+def test_the_casing_of_the_format_does_not_matter(tmp_path):
+    # The name carries the codec as the license spelled it, and only MPEG
+    # ever produces an `.mp3` here, so matching loosely cannot pick up a
+    # different quality of the same title.
+    (tmp_path / "a-title-mpeg.mp3").touch()
+
+    assert found(tmp_path, Item(None)) == ["a-title-mpeg.mp3"]
+
+
+def test_a_longer_title_starting_the_same_way_is_a_different_title(tmp_path):
+    # Titles carry hyphens, so `a-title`'s wildcard also lists the files of
+    # `a-title-longer`. Claiming one would skip a download that never
+    # happened. (`a-title` against `a-title2` needs no filter: the wildcard
+    # already demands the hyphen.)
+    (tmp_path / "a-title-longer-MPEG.mp3").touch()
+    (tmp_path / "a-title-MPEG.mp3").touch()
+
+    assert found(tmp_path, Item(None)) == ["a-title-MPEG.mp3"]
+
+
+def test_a_title_with_brackets_is_not_read_as_a_pattern(tmp_path):
+    # Titles like "Star-Lord (Deutsch) [1]" are ordinary. Left unescaped,
+    # the brackets would become a character class and match nothing.
+    name = "Marvels Wastelanders [Star-Lord]"
+    (tmp_path / f"{name}-MPEG.mp3").touch()
+
+    got = [p.name for p in _finished_downloads(tmp_path, name, Item(None), "best")]
+
+    assert got == [f"{name}-MPEG.mp3"]
+
+
+@pytest.mark.parametrize("codec", ["AAX_44_128", None])
+def test_it_never_looks_outside_the_output_directory(tmp_path, codec):
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "a-title-MPEG.mp3").touch()
+
+    for candidate in _finished_downloads(tmp_path, "a-title", Item(codec), "best"):
+        assert candidate.parent == pathlib.Path(tmp_path)
+
+
+def test_the_download_command_actually_asks_where_to_look():
+    """`download_aaxc` has to use the generator, not build a name itself.
+
+    Read from the syntax tree: reaching that code for real needs a license
+    and the network, and a hand-built name looks identical until a podcast
+    episode is downloaded twice.
+    """
+    tree = ast.parse(inspect.getsource(cmd_download))
+    body = next(
+        ast.unparse(n)
+        for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "download_aaxc"
+    )
+
+    assert "_finished_downloads(" in body
+    assert ".aaxc'" not in body.split("_finished_downloads")[0], (
+        "the pre-check must not build a name of its own any more"
+    )


### PR DESCRIPTION
Re-running a download over a podcast shows this in the summary even though every episode is already on disk:

```
Unsaved voucher: 2
New voucher files: 8
```

Before asking for a license, `download_aaxc` looks for what an earlier attempt left behind and returns early when both the audio and its voucher are there. That saves a license request — and a license costs a voucher whether or not anything is found.

## Why it never fired for a podcast

The look-up asks `_get_codec`, which reads the codecs the library reported in advance, and builds `<name>-<codec>.aaxc`. A podcast episode has no `aax_*` codec, so the answer is `None` and the whole check was skipped.

Its name is not knowable that early. The format arrives *with the license*, and the file is named after whatever that said — MPEG for a podcast, in whatever casing Audible used. So these have to be looked for rather than constructed.

The audio itself was never re-fetched: the downloader sees the finished file before any network traffic. Only the voucher was spent.

## The change

A small generator yields the candidates: the exact AAXC name when a codec is known, otherwise what the folder actually holds for this title.

The voucher counts as a find as well as the audio. It is written before the audio is renamed into place, so a download that failed in between leaves one behind, and the retry can reuse that license instead of paying for another. That is the same courtesy AAXC already got.

Two things the wildcard needs:

- **What follows the title must be exactly the format.** Titles carry hyphens, so `Foo` would otherwise claim a file belonging to `Foo-Bar`. Measured: `Foo-*.mp3` does list `Foo-Bar-MPEG.mp3`. (`Foo` against `Foo2` needs no filter — the wildcard already demands the hyphen.)
- **The title is escaped.** `Marvels Wastelanders [Star-Lord]` would otherwise be read as a character class and match nothing.

MPEG stays something to look for, never an assumed format. Nothing here sets the codec; a fetch still asks for a license, and that request advertises both MPEG and ADRM.

## Tests

161 green, 11 new in `tests/test_finished_downloads.py`, none touching the network. Mutation-checked:

| reverted | result |
|---|---|
| voucher no longer counts as a find | 1 failed |
| exact-format filter removed | 1 failed |
| duplicates no longer collapsed | 1 failed |
| caller builds the name itself again | 1 failed |
| unchanged | 161 passed |

The last one is a syntax-tree test: `download_aaxc` has to use the generator rather than construct a name, because a hand-built name looks identical until a podcast episode is downloaded twice.