### PR TITLE
fix: a missing cover size is a warning, not an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- A cover size a title does not offer is reported as a warning, not an error (#300)
 - Try a request to Audible's CDE host up to three times when it gets no answer, waiting a little longer each time. A dropped connection on the annotations endpoint used to end a whole `-j 8` run. An HTTP status is an answer and is never retried, 404 included (#298)
 - A failed download job now names itself: the command, the title and the ASIN, instead of the bare exception (#298)
 - AAXC downloads of podcast episodes are no longer rejected over the `audio/mp3` content type Audible sends for them. The AAX path keeps its own, narrower list: it always writes a `.aax` file, so accepting an MP3 there would misname it (#297)

--- a/src/audible_cli/cmds/cmd_download.py
+++ b/src/audible_cli/cmds/cmd_download.py
@@ -179,7 +179,9 @@ async def download_cover(
 
     url = item.get_cover_url(res)
     if url is None:
-        logger.error("No COVER with size %s found for %s", res, item.full_title)
+        # A step above the other "nothing to fetch" cases here: this size
+        # was asked for.
+        logger.warning("No COVER with size %s found for %s", res, item.full_title)
         return
 
     dl = Downloader(url, filepath, client, overwrite_existing, "image/jpeg")

--- a/tests/test_cover_sizes.py
+++ b/tests/test_cover_sizes.py
@@ -1,0 +1,34 @@
+"""Asking for a cover size a title does not have."""
+
+import asyncio
+import logging
+
+from audible_cli.cmds.cmd_download import download_cover
+
+
+class Item:
+    full_title = "Sternengeschichten Folge 716"
+
+    def get_cover_url(self, res):
+        return None
+
+
+def test_a_missing_size_is_a_warning_not_an_error(tmp_path, caplog):
+    # It aborts nothing, so reporting it as an error made a podcast run
+    # look like it had gone wrong.
+    with caplog.at_level(logging.DEBUG, logger="audible_cli.cmds.cmd_download"):
+        asyncio.run(
+            download_cover(
+                client=None,
+                output_dir=tmp_path,
+                base_filename="a-title",
+                item=Item(),
+                res=500,
+                overwrite_existing=False,
+            )
+        )
+
+    said = [(r.levelname, r.getMessage()) for r in caplog.records]
+    assert said == [
+        ("WARNING", "No COVER with size 500 found for Sternengeschichten Folge 716")
+    ]


### PR DESCRIPTION
Downloading a podcast fills the log with lines like this:

```
error: No COVER with size 500 found for Sternengeschichten Folge 716: Kallisto …
error: No COVER with size 598 found for Sternengeschichten Folge 598: Der Gas-Torus von Io
```

Nothing is aborted over it. The rest of the title is fetched, the run carries on, and the exit code is unaffected — but a run of hundreds of episodes looks like it has gone wrong.

Episodes routinely offer fewer cover sizes than a book, so this is the normal case for a podcast, not a fault.

Now a warning. The other "nothing to fetch" cases in the same file — no PDF, no chapters, no annotations — say `info`; this one stays a step above because a size was explicitly asked for and does not exist, which is worth seeing.

Tested, and mutation-checked: putting it back to `error` fails the new test.