### PR TITLE
fix: let `--version` answer even when the update check fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `--version` no longer exits 1 with the error glued to the version when the update check cannot reach GitHub (#309)
 - A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
 - A request to Audible's CDE host is tried up to three times when it gets no answer (#298)

--- a/src/audible_cli/decorators.py
+++ b/src/audible_cli/decorators.py
@@ -84,8 +84,17 @@ def version_option(func=None, **kwargs):
             response = httpx.get(url, headers=headers, follow_redirects=True)
             response.raise_for_status()
         except Exception as e:
-            logger.error(e)
-            raise click.Abort() from e
+            # The version was the question and it has been answered. The
+            # update check is a courtesy: it must not glue its message to
+            # the version line, and it must not turn `--version` into a
+            # nonzero exit for a script that only wanted the number.
+            click.echo()
+            click.echo(
+                f"Could not check for a newer release: {e}",
+                color=ctx.color,
+                err=True
+            )
+            ctx.exit()
 
         content = response.json()
 

--- a/tests/test_version_option.py
+++ b/tests/test_version_option.py
@@ -1,0 +1,69 @@
+"""`--version` answers a question a script may be asking.
+
+The version goes to stdout on a line of its own. The update check that
+follows it is a courtesy: it may fail, and when it does it must not take
+the answer or the exit code with it.
+"""
+
+from unittest import mock
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from audible_cli import __version__
+from audible_cli.cli import cli
+
+
+def release(tag):
+    """A GitHub release response naming `tag` as the latest version."""
+    response = mock.Mock()
+    response.json.return_value = {
+        "tag_name": tag,
+        "html_url": "https://github.example/releases/latest",
+    }
+    return response
+
+
+def run(get):
+    """Invoke `audible --version` with `get` standing in for httpx."""
+    with mock.patch("audible_cli.decorators.httpx.get", get):
+        return CliRunner().invoke(cli, ["--version"])
+
+
+def test_a_failed_update_check_still_answers_the_question():
+    # `v=$(audible --version)` on a machine with no network used to come
+    # back as "audible-cli, version 0.5.1error: no route" and exit 1.
+    result = run(mock.Mock(side_effect=httpx.ConnectError("no route")))
+
+    assert result.exit_code == 0
+    assert result.stdout == f"audible-cli, version {__version__}\n"
+    assert "Could not check for a newer release: no route" in result.stderr
+
+
+def test_the_answer_survives_whatever_the_check_raises():
+    # Anything the request or the response can throw, not just the one
+    # error the other test uses.
+    for failure in (
+        httpx.ReadTimeout("too slow"),
+        httpx.HTTPStatusError("rate limited", request=None, response=None),
+        ValueError("nonsense from the API"),
+    ):
+        result = run(mock.Mock(side_effect=failure))
+
+        assert result.exit_code == 0, failure
+        assert result.stdout == f"audible-cli, version {__version__}\n", failure
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("0.0.1", "(up-to-date)"),
+        ("99.0.0", "(update available)"),
+    ],
+)
+def test_a_check_that_works_reads_as_it_always_did(tag, expected):
+    result = run(mock.Mock(return_value=release(tag)))
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith(f"audible-cli, version {__version__} {expected}")


### PR DESCRIPTION
`audible --version` prints the version without a newline, then asks GitHub for the latest release so it can append `(up-to-date)` or `(update available)` to the same line. When that call fails, the error is appended instead and the run aborts:

```console
$ audible --version          # no network
audible-cli, version 0.5.1error: no route
$ echo $?
1
```

So `v=$(audible --version)` comes back with the error glued to the number, and a non-zero exit, on any machine that cannot reach GitHub — an installation that is otherwise working perfectly.

The update check is a courtesy. It now finishes the version line, says on stderr why it could not look, and exits 0:

```console
$ audible --version          # no network
audible-cli, version 0.5.1
$ echo $?
0
$ audible --version 2>&1 >/dev/null
Could not check for a newer release: no route
```

A successful check reads exactly as before, on stdout and on the same line.

`tests/test_version_option.py` covers both, including the failure being any exception the request or the response decoding can raise, since the `except` clause catches all of them.

### Note

PR #306 touches these same lines: it gives the version a line of its own on stdout and moves both notices to stderr as part of the output-stream contract. This branch is the narrower fix and stands on its own, so whichever lands first leaves a small conflict in that one block for the other.
