### PR TITLE
fix: keep every part of an api request the caller wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `audible api` no longer drops a query written into the endpoint: `api "library?num_results=5"` used to ask for the library without it (#NNN)
+- `audible api` no longer repeats a query parameter into oblivion: giving the same key twice used to keep only the last (#NNN)
+- A malformed `--query`, `--body` or `--indent` is now a usage error instead of a traceback and exit 3 (#NNN)
+- `audible api` honours `--timeout` like every other command, rather than the library default of 10 seconds (#NNN)
 - `--version` no longer exits 1 with the error glued to the version when the update check cannot reach GitHub (#309)
 - A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
@@ -18,6 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `audible api` takes a path, not a URL. An absolute URL used to be sent as given, with the request signed for that host; the endpoint is now rejected before any credentials are loaded. The other hosts audible-cli talks to move to the new `audible request` (#NNN)
+- `audible api` requires a JSON response. A 200 carrying something else — an HTML maintenance page, say — used to be quoted into a JSON string and reported as success (#NNN)
+- `audible api` refuses what it cannot send: a body on a `GET` or a `DELETE`, an endpoint that names nothing, a fragment. The body used to be parsed and then left behind (#NNN)
+- `audible api -f dict` is gone. It printed the answer as a Python literal, which no json reader takes, and `--indent` was ignored for it; with `--output` it failed with a `TypeError`. `--format` accepts only `json` now, and says it is on its way out (#NNN)
+- `audible api --param` is now spelled `--query`/`-q`. The old spelling still works and says so; `-p` no longer belongs to this command, because it is the password option on the group (#NNN)
 - Log output now goes to stderr, so stdout carries only what a command produces; `audible download … > log.txt` needs `2>` or the new `--log-file` from now on (#306)
 - Nine remaining status messages became log messages, so `--verbosity` reaches them too (#306)
 - `--version` prints the version alone; the update notice goes to stderr (#306)
@@ -27,6 +36,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `audible api --body-file` reads the request body from a file, or from standard input with `-` (#NNN)
+- `audible api --header/-H` sends a request header, the same name as often as needed; the headers that carry the authentication or describe the body are refused (#NNN)
+- `audible api --dump-header/-D` writes the status line and the response headers to a file, which is where `total-count` and `continuation-token` come from (#NNN)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `audible api` no longer drops a query written into the endpoint: `api "library?num_results=5"` used to ask for the library without it (#NNN)
-- `audible api` no longer repeats a query parameter into oblivion: giving the same key twice used to keep only the last (#NNN)
-- A malformed `--query`, `--body` or `--indent` is now a usage error instead of a traceback and exit 3 (#NNN)
-- `audible api` honours `--timeout` like every other command, rather than the library default of 10 seconds (#NNN)
+- `audible api` no longer drops a query written into the endpoint: `api "library?num_results=5"` used to ask for the library without it (#311)
+- `audible api` no longer repeats a query parameter into oblivion: giving the same key twice used to keep only the last (#311)
+- A malformed `--query`, `--body` or `--indent` is now a usage error instead of a traceback and exit 3 (#311)
+- `audible api` honours `--timeout` like every other command, rather than the library default of 10 seconds (#311)
 - `--version` no longer exits 1 with the error glued to the version when the update check cannot reach GitHub (#309)
 - A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
@@ -22,11 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- `audible api` takes a path, not a URL. An absolute URL used to be sent as given, with the request signed for that host; the endpoint is now rejected before any credentials are loaded. The other hosts audible-cli talks to move to the new `audible request` (#NNN)
-- `audible api` requires a JSON response. A 200 carrying something else — an HTML maintenance page, say — used to be quoted into a JSON string and reported as success (#NNN)
-- `audible api` refuses what it cannot send: a body on a `GET` or a `DELETE`, an endpoint that names nothing, a fragment. The body used to be parsed and then left behind (#NNN)
-- `audible api -f dict` is gone. It printed the answer as a Python literal, which no json reader takes, and `--indent` was ignored for it; with `--output` it failed with a `TypeError`. `--format` accepts only `json` now, and says it is on its way out (#NNN)
-- `audible api --param` is now spelled `--query`/`-q`. The old spelling still works and says so; `-p` no longer belongs to this command, because it is the password option on the group (#NNN)
+- `audible api` takes a path, not a URL. An absolute URL used to be sent as given, with the request signed for that host; the endpoint is now rejected before any credentials are loaded. The other hosts audible-cli talks to move to the new `audible request` (#311)
+- `audible api` requires a JSON response. A 200 carrying something else — an HTML maintenance page, say — used to be quoted into a JSON string and reported as success (#311)
+- `audible api` refuses what it cannot send: a body on a `GET` or a `DELETE`, an endpoint that names nothing, a fragment. The body used to be parsed and then left behind (#311)
+- `audible api -f dict` is gone. It printed the answer as a Python literal, which no json reader takes, and `--indent` was ignored for it; with `--output` it failed with a `TypeError`. `--format` accepts only `json` now, and says it is on its way out (#311)
+- `audible api --param` is now spelled `--query`/`-q`. The old spelling still works and says so; `-p` no longer belongs to this command, because it is the password option on the group (#311)
 - Log output now goes to stderr, so stdout carries only what a command produces; `audible download … > log.txt` needs `2>` or the new `--log-file` from now on (#306)
 - Nine remaining status messages became log messages, so `--verbosity` reaches them too (#306)
 - `--version` prints the version alone; the update notice goes to stderr (#306)
@@ -36,9 +36,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible api --body-file` reads the request body from a file, or from standard input with `-` (#NNN)
-- `audible api --header/-H` sends a request header, the same name as often as needed; the headers that carry the authentication or describe the body are refused (#NNN)
-- `audible api --dump-header/-D` writes the status line and the response headers to a file, which is where `total-count` and `continuation-token` come from (#NNN)
+- `audible api --body-file` reads the request body from a file, or from standard input with `-` (#311)
+- `audible api --header/-H` sends a request header, the same name as often as needed; the headers that carry the authentication or describe the body are refused (#311)
+- `audible api --dump-header/-D` writes the status line and the response headers to a file, which is where `total-count` and `continuation-token` come from (#311)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/README.md
+++ b/README.md
@@ -337,6 +337,46 @@ Show help:
 audible <command> -h
 ```
 
+### Calling the API
+
+`api` takes a **path**, not a URL — the marketplace comes from the profile or
+from `--country-code`, so it is decided in one place:
+
+```shell
+audible api library -q num_results=10 -q response_groups=product_desc
+audible api "catalog/products/B07J2M2VC7?response_groups=media"
+```
+
+A query written into the path and one given with `--query` add up, and the
+same key may appear more than once. The response has to be JSON; an answer
+that is not gets reported as a failure rather than quoted into one.
+
+The query used to be `--param`, which still works and says it is old. Its
+short form `-p` is gone: on the group it is the password, so
+`audible -p num_results=5 api library` would have offered the query as a
+password. Repeatable request headers go out with `--header`:
+
+```shell
+audible api library -H "Accept-Language: en-US"
+```
+
+A body that is long enough to be awkward on a command line comes from a
+file, or through a pipe:
+
+```shell
+audible api wishlist -m POST --body-file payload.json
+generate-payload | audible api wishlist -m POST --body-file -
+```
+
+Some of what the API tells you arrives in the headers rather than the body —
+`total-count`, and the `continuation-token` a script needs to fetch the next
+page. `--dump-header` writes them to a file while stdout stays JSON:
+
+```shell
+audible api "library?num_results=50" -D headers.txt > page1.json
+grep continuation-token headers.txt
+```
+
 ---
 
 ## 🔧 Plugins & Extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ exclude = [
     "README.md",
     "src/audible_cli/cli.py",
     "src/audible_cli/cmds/cmd_activation_bytes.py",
-    "src/audible_cli/cmds/cmd_api.py",
     "src/audible_cli/cmds/cmd_download.py",
     "src/audible_cli/cmds/cmd_library.py",
     "src/audible_cli/cmds/cmd_manage.py",

--- a/src/audible_cli/cmds/cmd_api.py
+++ b/src/audible_cli/cmds/cmd_api.py
@@ -1,108 +1,412 @@
+"""Send one request to the Audible API and print what came back.
+
+This command is for the API and its JSON. An endpoint is a path, never a
+URL: the host follows from the profile or from `--country-code`, so there
+is one place where the marketplace is decided. For the other hosts
+audible-cli talks to, and for answers that are not JSON, there is
+`audible request`.
+"""
+
 import json
 import logging
 import pathlib
-import sys
 
 import click
-from audible import Client
+import httpx
+from audible.client import raise_for_status
+from click.core import ParameterSource
 
 from ..constants import AVAILABLE_MARKETPLACES
-from ..decorators import pass_session
+from ..decorators import pass_session, run_async, timeout_option
+from ..exceptions import AudibleCliException
 
 
 logger = logging.getLogger("audible_cli.cmds.cmd_api")
 
 
+class ApiPath(click.ParamType):
+    """An API path, with an optional query string.
+
+    The query is read into pairs and sent as pairs, which means it is
+    decoded as UTF-8 and encoded again. A percent escape that is not
+    UTF-8, such as `%FF`, does not survive that; the path does, because
+    it is passed on as it was written.
+    """
+
+    name = "path"
+
+    def convert(self, value, param, ctx):
+        """Take the path apart, and refuse anything carrying a host.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The path without its query, and the query as a list of pairs.
+        """
+        try:
+            url = httpx.URL(value)
+        except httpx.InvalidURL as error:
+            self.fail(f"{value!r} is not a path: {error}", param, ctx)
+
+        if url.scheme or url.netloc:
+            self.fail(
+                f"{value!r} is a URL. This command takes a path, such as "
+                f"'library' -- the host comes from the profile or "
+                f"--country-code. Use 'audible request' for a URL.",
+                param,
+                ctx,
+            )
+
+        if url.fragment:
+            self.fail(
+                f"{value!r} carries a fragment, which is never sent to a "
+                f"server. Write it as %23 if it belongs to the path.",
+                param,
+                ctx,
+            )
+
+        # `url.path` decodes percent escapes, which would turn `%2F` in an
+        # asin into a path separator. The raw form carries the query too,
+        # so it is cut off here rather than read from `url.path`.
+        path = url.raw_path.split(b"?", 1)[0].decode()
+
+        # httpx reads an empty path as `/`, so `api ""` and `api "?a=1"`
+        # would ask for the root of the API rather than for an endpoint.
+        if path == "/":
+            self.fail("no endpoint. Give a path such as 'library'", param, ctx)
+
+        query = list(url.params.multi_items())
+
+        if any(not key for key, _ in query):
+            self.fail(f"{value!r} has a query parameter without a name",
+                      param, ctx)
+
+        return path, query
+
+
+class QueryPair(click.ParamType):
+    """One `key=value` query parameter."""
+
+    name = "key[=value]"
+
+    def convert(self, value, param, ctx):
+        """Split at the first `=` only, so a value may contain more.
+
+        A key on its own is a query parameter without a value. httpx sends
+        it as `key=`; a bare `key` cannot be expressed through it.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The key and the value, which may be empty.
+        """
+        key, _, val = value.partition("=")
+
+        if not key:
+            self.fail(f"{value!r} has no name", param, ctx)
+
+        return key, val
+
+
+#: Header names a caller may not set. They carry the authentication, or
+#: they describe a body this command always writes itself: the body is
+#: JSON, and the client says so.
+REFUSED_HEADERS = frozenset({
+    "authorization",
+    "content-length",
+    "content-type",
+    "host",
+    "proxy-authorization",
+    "transfer-encoding",
+    "x-adp-alg",
+    "x-adp-signature",
+    "x-adp-token",
+    "x-amz-access-token",
+})
+
+
+class HeaderPair(click.ParamType):
+    """One `Name: value` request header."""
+
+    name = "name: value"
+
+    def convert(self, value, param, ctx):
+        """Split at the first colon, and refuse what is not ours to set.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The header name and its value.
+        """
+        name, sep, val = value.partition(":")
+        name = name.strip()
+
+        if not sep or not name:
+            self.fail(f"{value!r} is not 'Name: value'", param, ctx)
+
+        if name.lower() in REFUSED_HEADERS:
+            self.fail(
+                f"{name} is set by audible-cli itself and cannot be given here",
+                param,
+                ctx,
+            )
+
+        return name, val.strip()
+
+
+def load_json(text):
+    """Read JSON, and only JSON.
+
+    Python also reads `NaN` and `Infinity`, which no JSON parser on the
+    other side has to understand and which cannot be serialised back.
+    They are rejected here rather than half way through the request.
+
+    Args:
+        text: The document to read.
+
+    Returns:
+        Whatever the JSON describes.
+
+    Raises:
+        ValueError: If `text` is not JSON.
+    """
+    def refuse(constant):
+        raise ValueError(f"{constant} is not part of json")
+
+    return json.loads(text, parse_constant=refuse)
+
+
+class JsonBody(click.ParamType):
+    """A request body, given as JSON."""
+
+    name = "json"
+
+    def convert(self, value, param, ctx):
+        """Parse the body before anything else happens.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            Whatever the JSON describes.
+        """
+        try:
+            return load_json(value)
+        except ValueError as error:
+            self.fail(f"not valid JSON: {error}", param, ctx)
+
+
+def resolve_body(options):
+    """Work out the body to send, and whether one was asked for.
+
+    `--body null` parses to None, and so does an option nobody gave, so
+    the two are told apart by where the value came from rather than by
+    what it is. Neither ends up on the wire: the client hands the body to
+    httpx as `json=`, and `json=None` writes an empty body, not `null`.
+
+    A file is read here, before the credentials are. With `-` the body is
+    standard input, and a password prompt would find it exhausted.
+
+    Args:
+        options: The parsed command line.
+
+    Returns:
+        The body, and whether the caller gave one.
+
+    Raises:
+        click.UsageError: If both ways of giving a body were used, if the
+            file is not JSON, or if the body is `null`.
+    """
+    context = click.get_current_context()
+    given = context.get_parameter_source("body") is not ParameterSource.DEFAULT
+    body = options["body"]
+
+    if options["body_file"] is not None:
+        if given:
+            raise click.UsageError(
+                "--body and --body-file cannot both be given"
+            )
+        try:
+            body = load_json(options["body_file"].read())
+        except ValueError as error:
+            raise click.UsageError(
+                f"{options['body_file'].name} is not valid JSON: {error}"
+            ) from error
+        given = True
+
+    if given and body is None:
+        raise click.UsageError(
+            "`null` cannot be sent as a body. Leave the option out to send "
+            "none, or use 'audible request' for a body of your own."
+        )
+
+    return body, given
+
+
 @click.command("api")
-@click.argument("endpoint")
+@click.argument("endpoint", type=ApiPath())
 @click.option(
     "--method", "-m",
-    type=click.Choice(
-        ["GET", "POST", "DELETE", "PUT"],
-        case_sensitive=False
-    ),
+    type=click.Choice(["GET", "POST", "DELETE", "PUT"], case_sensitive=False),
     default="GET",
     help="The http request method",
     show_default=True,
 )
 @click.option(
-    "--param", "-p",
+    "--query", "-q",
+    type=QueryPair(),
+    multiple=True,
     help="A query parameter (e.g. num_results=5). Only one parameter "
-         "per option. Multiple options of this type are allowed.",
-    multiple=True
+         "per option. Multiple options of this type are allowed, including "
+         "the same key more than once.",
+)
+@click.option(
+    "--param",
+    type=QueryPair(),
+    multiple=True,
+    deprecated="use --query instead",
+    help="An earlier spelling of --query.",
+)
+@click.option(
+    "--header", "-H",
+    type=HeaderPair(),
+    multiple=True,
+    help="A request header (e.g. 'Accept-Language: en-US'). Repeatable, "
+         "including the same name twice. The headers that carry the "
+         "authentication or describe the body belong to the client and "
+         "are refused here.",
 )
 @click.option(
     "--body", "-b",
-    help="The json formatted body to send"
+    type=JsonBody(),
+    help="The json formatted body to send",
+)
+@click.option(
+    "--body-file",
+    type=click.File("r", encoding="utf-8"),
+    help="Read the json formatted body from a file. `-` reads it from "
+         "standard input, which then cannot answer a password prompt.",
 )
 @click.option(
     "--indent", "-i",
-    help="pretty-printed output with indent level"
+    type=click.IntRange(min=0),
+    help="pretty-printed output with indent level",
 )
 @click.option(
     "--format", "-f",
-    type=click.Choice(
-        ["json", "dict"],
-    ),
+    type=click.Choice(["json"]),
     default="json",
-    help="The output format. If 'dict', the output is a unformatted Python dict.",
-    show_default=True,
+    deprecated="the answer is json, and json is what this writes",
+    help="An earlier choice between json and a Python dict.",
 )
 @click.option(
     "--output", "-o",
     type=click.Path(path_type=pathlib.Path),
-    help="Output the response to a file"
+    help="Write the response to a file, as UTF-8. Worth having over a shell "
+         "redirect on Windows, where `>` writes UTF-16 or the console "
+         "codepage.",
+)
+@click.option(
+    "--dump-header", "-D",
+    type=click.Path(path_type=pathlib.Path),
+    help="Write the status line and the response headers to a file. The API "
+         "returns `continuation-token` and `total-count` there, which is how "
+         "a script pages through a long answer.",
 )
 @click.option(
     "--country-code", "-c",
     type=click.Choice(AVAILABLE_MARKETPLACES),
     help="Requested Audible marketplace. If not set, the country code for "
-         "the current profile is used."
+         "the current profile is used.",
 )
+@timeout_option
 @pass_session
-def cli(session, **options):
+@run_async
+async def cli(session, **options):
     """Send requests to an Audible API endpoint.
+
+    ENDPOINT is a path such as `library` or `1.0/library`, and may carry a
+    query string of its own; `--query` adds to it rather than replacing
+    it. The response has to be JSON; anything else is reported as a
+    failure rather than quoted into one.
 
     Take a look at
     https://audible.readthedocs.io/en/latest/misc/external_api.html for known
     endpoints and parameters.
     """
-    auth = session.auth
-    endpoint = options.get("endpoint")
-    method = options.get("method")
+    path, embedded = options["endpoint"]
+    body, has_body = resolve_body(options)
 
-    params = {}
-    for p in options.get("param"):
-        k, v = p.split("=")
-        params[k] = v
+    # The client offers one method per verb rather than a single `request`,
+    # and the two that carry a body take it positionally.
+    method = options["method"].upper()
+    carried = [body] if method in ("POST", "PUT") else []
 
-    body = options.get("body")
-    if body is not None:
-        body = json.loads(body)
+    if has_body and not carried:
+        raise click.UsageError(f"a {method} carries no body")
 
-    indent = options.get("indent")
-    if indent is not None:
+    # A query given in the endpoint and one given as options are both the
+    # caller's, so they are sent together rather than one replacing the
+    # other. Repeats survive: the API reads `asins=A&asins=B` as two.
+    params = embedded + list(options["query"]) + list(options["param"])
+    headers = list(options["header"]) or None
+
+    client = session.get_client(country_code=options["country_code"])
+    send = getattr(client, method.lower())
+
+    async with client.session:
         try:
-            indent = int(indent)
-        except ValueError:
-            pass
+            response = await send(
+                path,
+                *carried,
+                params=params,
+                headers=headers,
+                response_callback=lambda resp: resp,
+            )
+        except Exception as error:
+            raise AudibleCliException(str(error)) from error
 
-    output_format = options.get("format")
-    output_filename = options.get("output")
-    country_code = options.get("country_code")
+    # Written before the status is judged: a failed call is exactly when
+    # somebody wants to see what came back.
+    if options["dump_header"] is not None:
+        head = (f"{response.http_version} {response.status_code} "
+                f"{response.reason_phrase}\n")
+        head += "".join(f"{name}: {value}\n"
+                        for name, value in response.headers.items())
+        options["dump_header"].write_text(head, encoding="utf-8")
+        logger.info("Headers saved to %s", options["dump_header"].resolve())
+
+    # The library turns a status into one of its own exceptions. Left
+    # alone it would reach `main()` as an unexpected error and exit 3.
+    try:
+        raise_for_status(response)
+    except Exception as error:
+        raise AudibleCliException(str(error)) from error
 
     try:
-        with Client(auth=auth, country_code=country_code) as client:
-            r = client._request(method, endpoint, params=params, json=body)
-    except Exception as e:
-        logger.error(e)
-        sys.exit(1)
+        answer = response.json()
+    except ValueError as error:
+        raise AudibleCliException(
+            f"The answer is not JSON, which is what this command is for. "
+            f"Use 'audible request' to see it as it came: {error}"
+        ) from error
 
-    if output_format == "json":
-        r = json.dumps(r, indent=indent)
+    answer = json.dumps(answer, indent=options["indent"])
 
-    if output_filename is None:
-        click.echo(r)
+    output = options["output"]
+    if output is None:
+        click.echo(answer)
     else:
-        output_filename.write_text(r)
-        logger.info("Output saved to %s", output_filename.resolve())
+        output.write_text(answer, encoding="utf-8")
+        logger.info("Output saved to %s", output.resolve())

--- a/src/audible_cli/cmds/cmd_api.py
+++ b/src/audible_cli/cmds/cmd_api.py
@@ -81,8 +81,7 @@ class ApiPath(click.ParamType):
         query = list(url.params.multi_items())
 
         if any(not key for key, _ in query):
-            self.fail(f"{value!r} has a query parameter without a name",
-                      param, ctx)
+            self.fail(f"{value!r} has a query parameter without a name", param, ctx)
 
         return path, query
 
@@ -117,18 +116,20 @@ class QueryPair(click.ParamType):
 #: Header names a caller may not set. They carry the authentication, or
 #: they describe a body this command always writes itself: the body is
 #: JSON, and the client says so.
-REFUSED_HEADERS = frozenset({
-    "authorization",
-    "content-length",
-    "content-type",
-    "host",
-    "proxy-authorization",
-    "transfer-encoding",
-    "x-adp-alg",
-    "x-adp-signature",
-    "x-adp-token",
-    "x-amz-access-token",
-})
+REFUSED_HEADERS = frozenset(
+    {
+        "authorization",
+        "content-length",
+        "content-type",
+        "host",
+        "proxy-authorization",
+        "transfer-encoding",
+        "x-adp-alg",
+        "x-adp-signature",
+        "x-adp-token",
+        "x-amz-access-token",
+    }
+)
 
 
 class HeaderPair(click.ParamType):
@@ -179,6 +180,7 @@ def load_json(text):
     Raises:
         ValueError: If `text` is not JSON.
     """
+
     def refuse(constant):
         raise ValueError(f"{constant} is not part of json")
 
@@ -234,9 +236,7 @@ def resolve_body(options):
 
     if options["body_file"] is not None:
         if given:
-            raise click.UsageError(
-                "--body and --body-file cannot both be given"
-            )
+            raise click.UsageError("--body and --body-file cannot both be given")
         try:
             body = load_json(options["body_file"].read())
         except ValueError as error:
@@ -257,19 +257,21 @@ def resolve_body(options):
 @click.command("api")
 @click.argument("endpoint", type=ApiPath())
 @click.option(
-    "--method", "-m",
+    "--method",
+    "-m",
     type=click.Choice(["GET", "POST", "DELETE", "PUT"], case_sensitive=False),
     default="GET",
     help="The http request method",
     show_default=True,
 )
 @click.option(
-    "--query", "-q",
+    "--query",
+    "-q",
     type=QueryPair(),
     multiple=True,
     help="A query parameter (e.g. num_results=5). Only one parameter "
-         "per option. Multiple options of this type are allowed, including "
-         "the same key more than once.",
+    "per option. Multiple options of this type are allowed, including "
+    "the same key more than once.",
 )
 @click.option(
     "--param",
@@ -279,16 +281,18 @@ def resolve_body(options):
     help="An earlier spelling of --query.",
 )
 @click.option(
-    "--header", "-H",
+    "--header",
+    "-H",
     type=HeaderPair(),
     multiple=True,
     help="A request header (e.g. 'Accept-Language: en-US'). Repeatable, "
-         "including the same name twice. The headers that carry the "
-         "authentication or describe the body belong to the client and "
-         "are refused here.",
+    "including the same name twice. The headers that carry the "
+    "authentication or describe the body belong to the client and "
+    "are refused here.",
 )
 @click.option(
-    "--body", "-b",
+    "--body",
+    "-b",
     type=JsonBody(),
     help="The json formatted body to send",
 )
@@ -296,39 +300,44 @@ def resolve_body(options):
     "--body-file",
     type=click.File("r", encoding="utf-8"),
     help="Read the json formatted body from a file. `-` reads it from "
-         "standard input, which then cannot answer a password prompt.",
+    "standard input, which then cannot answer a password prompt.",
 )
 @click.option(
-    "--indent", "-i",
+    "--indent",
+    "-i",
     type=click.IntRange(min=0),
     help="pretty-printed output with indent level",
 )
 @click.option(
-    "--format", "-f",
+    "--format",
+    "-f",
     type=click.Choice(["json"]),
     default="json",
     deprecated="the answer is json, and json is what this writes",
     help="An earlier choice between json and a Python dict.",
 )
 @click.option(
-    "--output", "-o",
+    "--output",
+    "-o",
     type=click.Path(path_type=pathlib.Path),
     help="Write the response to a file, as UTF-8. Worth having over a shell "
-         "redirect on Windows, where `>` writes UTF-16 or the console "
-         "codepage.",
+    "redirect on Windows, where `>` writes UTF-16 or the console "
+    "codepage.",
 )
 @click.option(
-    "--dump-header", "-D",
+    "--dump-header",
+    "-D",
     type=click.Path(path_type=pathlib.Path),
     help="Write the status line and the response headers to a file. The API "
-         "returns `continuation-token` and `total-count` there, which is how "
-         "a script pages through a long answer.",
+    "returns `continuation-token` and `total-count` there, which is how "
+    "a script pages through a long answer.",
 )
 @click.option(
-    "--country-code", "-c",
+    "--country-code",
+    "-c",
     type=click.Choice(AVAILABLE_MARKETPLACES),
     help="Requested Audible marketplace. If not set, the country code for "
-         "the current profile is used.",
+    "the current profile is used.",
 )
 @timeout_option
 @pass_session
@@ -380,10 +389,12 @@ async def cli(session, **options):
     # Written before the status is judged: a failed call is exactly when
     # somebody wants to see what came back.
     if options["dump_header"] is not None:
-        head = (f"{response.http_version} {response.status_code} "
-                f"{response.reason_phrase}\n")
-        head += "".join(f"{name}: {value}\n"
-                        for name, value in response.headers.items())
+        head = (
+            f"{response.http_version} {response.status_code} {response.reason_phrase}\n"
+        )
+        head += "".join(
+            f"{name}: {value}\n" for name, value in response.headers.items()
+        )
         options["dump_header"].write_text(head, encoding="utf-8")
         logger.info("Headers saved to %s", options["dump_header"].resolve())
 

--- a/src/audible_cli/cmds/cmd_api.py
+++ b/src/audible_cli/cmds/cmd_api.py
@@ -10,12 +10,14 @@ audible-cli talks to, and for answers that are not JSON, there is
 import json
 import logging
 import pathlib
+from typing import Any, NoReturn
 
 import click
 import httpx
 from audible.client import raise_for_status
 from click.core import ParameterSource
 
+from ..config import Session
 from ..constants import AVAILABLE_MARKETPLACES
 from ..decorators import pass_session, run_async, timeout_option
 from ..exceptions import AudibleCliException
@@ -24,7 +26,7 @@ from ..exceptions import AudibleCliException
 logger = logging.getLogger("audible_cli.cmds.cmd_api")
 
 
-class ApiPath(click.ParamType):
+class ApiPath(click.ParamType[tuple[str, list[tuple[str, str]]]]):
     """An API path, with an optional query string.
 
     The query is read into pairs and sent as pairs, which means it is
@@ -35,7 +37,12 @@ class ApiPath(click.ParamType):
 
     name = "path"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, list[tuple[str, str]]]:
         """Take the path apart, and refuse anything carrying a host.
 
         Args:
@@ -86,12 +93,17 @@ class ApiPath(click.ParamType):
         return path, query
 
 
-class QueryPair(click.ParamType):
+class QueryPair(click.ParamType[tuple[str, str]]):
     """One `key=value` query parameter."""
 
     name = "key[=value]"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, str]:
         """Split at the first `=` only, so a value may contain more.
 
         A key on its own is a query parameter without a value. httpx sends
@@ -132,12 +144,17 @@ REFUSED_HEADERS = frozenset(
 )
 
 
-class HeaderPair(click.ParamType):
+class HeaderPair(click.ParamType[tuple[str, str]]):
     """One `Name: value` request header."""
 
     name = "name: value"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, str]:
         """Split at the first colon, and refuse what is not ours to set.
 
         Args:
@@ -164,7 +181,7 @@ class HeaderPair(click.ParamType):
         return name, val.strip()
 
 
-def load_json(text):
+def load_json(text: str) -> Any:
     """Read JSON, and only JSON.
 
     Python also reads `NaN` and `Infinity`, which no JSON parser on the
@@ -181,18 +198,23 @@ def load_json(text):
         ValueError: If `text` is not JSON.
     """
 
-    def refuse(constant):
+    def refuse(constant: str) -> NoReturn:
         raise ValueError(f"{constant} is not part of json")
 
     return json.loads(text, parse_constant=refuse)
 
 
-class JsonBody(click.ParamType):
+class JsonBody(click.ParamType[Any]):
     """A request body, given as JSON."""
 
     name = "json"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> Any:
         """Parse the body before anything else happens.
 
         Args:
@@ -209,7 +231,7 @@ class JsonBody(click.ParamType):
             self.fail(f"not valid JSON: {error}", param, ctx)
 
 
-def resolve_body(options):
+def resolve_body(options: dict[str, Any]) -> tuple[Any, bool]:
     """Work out the body to send, and whether one was asked for.
 
     `--body null` parses to None, and so does an option nobody gave, so
@@ -342,7 +364,7 @@ def resolve_body(options):
 @timeout_option
 @pass_session
 @run_async
-async def cli(session, **options):
+async def cli(session: Session, **options: Any) -> None:
     """Send requests to an Audible API endpoint.
 
     ENDPOINT is a path such as `library` or `1.0/library`, and may carry a

--- a/tests/test_cmd_api.py
+++ b/tests/test_cmd_api.py
@@ -1,0 +1,556 @@
+"""`audible api` asks the Audible API for JSON, and says so when it is not.
+
+The command takes a path, never a URL: the marketplace is decided in one
+place, by the profile or `--country-code`. Everything the caller typed as
+a query reaches the API, and nothing the caller typed is silently dropped.
+"""
+
+import json
+
+import httpx
+import pytest
+from audible.client import AsyncClient
+from click.testing import CliRunner
+
+from audible_cli.cmds import cmd_api
+from audible_cli.config import Session
+from audible_cli.exceptions import AudibleCliException
+
+
+class FakeHTTPSession:
+    """Stands in for the httpx session the client opens."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class FakeClient:
+    """Answers every verb, and remembers what it was asked."""
+
+    def __init__(self, response=None):
+        self.session = FakeHTTPSession()
+        self.asked = None
+        self._response = response
+
+    def _answer(self, method, path, body, params, headers=None):
+        self.asked = {
+            "method": method,
+            "path": path,
+            "body": body,
+            "params": list(params or []),
+            "headers": headers,
+        }
+        if self._response is not None:
+            return self._response
+        return httpx.Response(
+            200,
+            json={"items": [{"asin": "B01"}]},
+            request=httpx.Request(method, f"https://api.audible.de/1.0/{path}"),
+        )
+
+    async def get(self, path, response_callback=None, **kw):
+        return self._answer("GET", path, None, kw.get("params"), kw.get("headers"))
+
+    async def delete(self, path, response_callback=None, **kw):
+        return self._answer("DELETE", path, None, kw.get("params"), kw.get("headers"))
+
+    async def post(self, path, body, response_callback=None, **kw):
+        return self._answer("POST", path, body, kw.get("params"), kw.get("headers"))
+
+    async def put(self, path, body, response_callback=None, **kw):
+        return self._answer("PUT", path, body, kw.get("params"), kw.get("headers"))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A session handing out a client that never reaches the network."""
+    fake = FakeClient()
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+    return fake
+
+
+def run(*args, **kwargs):
+    return CliRunner().invoke(cmd_api.cli, list(args), **kwargs)
+
+
+def test_a_url_is_refused_and_says_where_to_go(client):
+    # The endpoint used to be handed to the client as typed, so an
+    # authenticated request went wherever it pointed.
+    result = run("https://foreign.host/collect")
+
+    assert result.exit_code == 2
+    assert "takes a path" in result.stderr
+    assert "audible request" in result.stderr
+    assert client.asked is None, "nothing may be sent before the check"
+
+
+@pytest.mark.parametrize(
+    "endpoint", ["https://api.audible.de/1.0/library", "//foreign.host/x", "http://x/y"]
+)
+def test_every_shape_of_url_is_refused(client, endpoint):
+    assert run(endpoint).exit_code == 2
+    assert client.asked is None
+
+
+def test_an_endpoint_that_is_no_url_at_all_is_a_usage_error(client):
+    # httpx raises InvalidURL on the port, which used to leave the command
+    # as an unexpected error with a traceback.
+    result = run("http://x:bad/path")
+
+    assert result.exit_code == 2
+    assert "is not a path" in result.stderr
+
+
+def test_a_refused_endpoint_never_builds_a_client(monkeypatch):
+    def refuse(self, **kw):
+        raise AssertionError("the credentials were loaded")
+
+    monkeypatch.setattr(Session, "get_client", refuse)
+
+    assert run("https://foreign.host/collect").exit_code == 2
+
+
+@pytest.mark.parametrize("endpoint", ["", "/", "?num_results=5"])
+def test_an_endpoint_is_required(client, endpoint):
+    # httpx reads all three as the path `/`, which is not an endpoint.
+    result = run(endpoint)
+
+    assert result.exit_code == 2
+    assert "no endpoint" in result.stderr
+    assert client.asked is None
+
+
+def test_a_fragment_is_refused(client):
+    # It never reaches a server, so sending the path without it would be
+    # answering a different question than the one that was asked.
+    result = run("library#items")
+
+    assert result.exit_code == 2
+    assert "fragment" in result.stderr
+    assert client.asked is None
+
+
+def test_a_query_in_the_path_survives(client):
+    # It used to be erased: the command always passed params={}, and httpx
+    # replaces the query with it.
+    run("library?num_results=5")
+
+    assert client.asked["params"] == [("num_results", "5")]
+
+
+def test_the_two_ways_of_giving_a_query_add_up(client):
+    run("library?num_results=5", "-q", "response_groups=media")
+
+    assert client.asked["params"] == [
+        ("num_results", "5"),
+        ("response_groups", "media"),
+    ]
+
+
+def test_a_value_may_contain_an_equals_sign(client):
+    run("library", "-q", "continuation_token=abc==")
+
+    assert client.asked["params"] == [("continuation_token", "abc==")]
+
+
+def test_the_same_key_twice_reaches_the_api_twice(client):
+    run("library", "-q", "asins=A", "-q", "asins=B")
+
+    assert client.asked["params"] == [("asins", "A"), ("asins", "B")]
+
+
+def test_a_key_on_its_own_is_a_query_without_a_value(client):
+    # A valid query parameter. httpx sends it as `flag=`.
+    run("library", "-q", "flag")
+
+    assert client.asked["params"] == [("flag", "")]
+
+
+def test_a_query_needs_at_least_a_name(client):
+    result = run("library", "-q", "=nothing")
+
+    assert result.exit_code == 2
+    assert "has no name" in result.stderr
+    assert client.asked is None
+
+
+def test_a_query_in_the_path_needs_a_name_too(client):
+    result = run("library?=nothing")
+
+    assert result.exit_code == 2
+    assert "without a name" in result.stderr
+    assert client.asked is None
+
+
+def test_the_old_spelling_still_works_and_says_it_is_old(client):
+    result = run("library", "--param", "num_results=5")
+
+    assert result.exit_code == 0
+    assert client.asked["params"] == [("num_results", "5")]
+    assert "The option 'param' is deprecated" in result.stderr
+
+
+def test_a_body_that_is_not_json_is_a_usage_error(client):
+    result = run("library", "-m", "POST", "-b", "{broken}")
+
+    assert result.exit_code == 2
+    assert "not valid JSON" in result.stderr
+    assert client.asked is None
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT"])
+def test_a_body_reaches_the_verbs_that_carry_one(client, method):
+    run("wishlist", "-m", method, "-b", '{"asin": "B01"}')
+
+    assert client.asked["method"] == method
+    assert client.asked["body"] == {"asin": "B01"}
+
+
+@pytest.mark.parametrize("method", ["GET", "DELETE"])
+def test_a_body_needs_a_verb_that_carries_one(monkeypatch, method):
+    # It used to be sent with any verb, and dropping it in silence would
+    # answer a different request than the one that was written.
+    def refuse(self, **kw):
+        raise AssertionError("the credentials were loaded")
+
+    monkeypatch.setattr(Session, "get_client", refuse)
+
+    result = run("wishlist/B01", "-m", method, "-b", '{"asin": "B01"}')
+
+    assert result.exit_code == 2
+    assert "carries no body" in result.stderr
+
+
+def test_a_verb_without_a_body_reaches_the_client(client):
+    run("wishlist/B01", "-m", "DELETE")
+
+    assert client.asked["method"] == "DELETE"
+    assert client.asked["path"] == "wishlist/B01"
+
+
+def test_the_country_code_reaches_the_client(monkeypatch):
+    fake = FakeClient()
+    asked = {}
+    monkeypatch.setattr(
+        Session, "get_client", lambda self, **kw: (asked.update(kw), fake)[1]
+    )
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    assert run("library", "-c", "us").exit_code == 0
+    assert asked == {"country_code": "us"}
+
+
+@pytest.mark.parametrize("body", ["NaN", '{"x": Infinity}'])
+def test_what_only_python_reads_as_json_is_refused(client, body):
+    # json.loads takes these; a body carrying one cannot be serialised
+    # back, and it used to fail after the credentials were loaded.
+    result = run("wishlist", "-m", "POST", "-b", body)
+
+    assert result.exit_code == 2
+    assert "not valid JSON" in result.stderr
+    assert client.asked is None
+
+
+def test_a_body_of_null_says_it_cannot_be_sent(client):
+    # `json=None` writes an empty body, so it would leave as no body.
+    result = run("wishlist", "-m", "POST", "-b", "null")
+
+    assert result.exit_code == 2
+    assert "cannot be sent as a body" in result.stderr
+    assert client.asked is None
+
+
+def test_a_body_of_null_still_counts_as_a_body(client, tmp_path):
+    # It parses to None like an option nobody gave, which used to let it
+    # slip past the check below.
+    path = tmp_path / "body.json"
+    path.write_text('{"asin": "B01"}', encoding="utf-8")
+
+    result = run("wishlist", "-m", "POST", "-b", "null", "--body-file", str(path))
+
+    assert result.exit_code == 2
+    assert "cannot both be given" in result.stderr
+    assert client.asked is None
+
+
+def test_an_indent_has_to_be_a_number(client):
+    result = run("library", "-i", "vier")
+
+    assert result.exit_code == 2
+    assert client.asked is None
+
+
+def test_the_answer_goes_to_stdout_as_json(client):
+    result = run("library")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"items": [{"asin": "B01"}]}
+    assert result.stderr == ""
+
+
+def test_an_indent_reaches_the_output(client):
+    result = run("library", "-i", "2")
+
+    assert result.stdout.startswith('{\n  "items"')
+
+
+def test_the_answer_can_go_to_a_file(client, tmp_path):
+    path = tmp_path / "library.json"
+
+    result = run("library", "-o", str(path))
+
+    assert result.exit_code == 0
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "items": [{"asin": "B01"}]
+    }
+    assert result.stdout == ""
+
+
+def test_a_python_dict_is_no_longer_an_output_format(client):
+    # It printed the answer as a Python literal, which is not json, and
+    # `--output` used to hand the dict itself to write_text.
+    result = run("library", "-f", "dict")
+
+    assert result.exit_code == 2
+    assert "not 'json'" in result.stderr
+    assert client.asked is None
+
+
+def test_the_format_option_still_works_and_says_it_is_old(client):
+    result = run("library", "-f", "json")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"items": [{"asin": "B01"}]}
+    assert "The option 'format' is deprecated" in result.stderr
+
+
+def test_an_answer_that_is_not_json_is_a_failure(monkeypatch):
+    # A maintenance page used to be quoted into a JSON string and exit 0,
+    # so a contract check saw valid JSON and passed.
+    html = httpx.Response(
+        200,
+        text="<html>down for maintenance</html>",
+        headers={"content-type": "text/html"},
+        request=httpx.Request("GET", "https://api.audible.de/1.0/library"),
+    )
+    fake = FakeClient(response=html)
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run("library")
+
+    # cli.main() maps this to exit 2; here the exception is what shows the
+    # command refused rather than quoting the page into JSON.
+    assert isinstance(result.exception, AudibleCliException)
+    assert result.stdout == ""
+    assert "not JSON" in str(result.exception)
+    assert "audible request" in str(result.exception)
+
+
+def test_an_error_status_is_a_failure(monkeypatch):
+    denied = httpx.Response(
+        404,
+        json={"message": "not found"},
+        request=httpx.Request("GET", "https://api.audible.de/1.0/nope"),
+    )
+    fake = FakeClient(response=denied)
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run("nope")
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "404" in str(result.exception)
+    assert result.stdout == ""
+
+
+def test_the_timeout_option_reaches_the_session(monkeypatch):
+    seen = {}
+
+    def get_client(self, **kw):
+        seen["timeout"] = self.params.get("timeout")
+        return FakeClient()
+
+    monkeypatch.setattr(Session, "get_client", get_client)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    run("library", "--timeout", "5")
+
+    assert seen["timeout"] == 5
+
+
+def test_the_path_keeps_its_percent_escapes(client):
+    # `httpx.URL(...).path` decodes them, which would turn `%2F` in an asin
+    # into a path separator and ask for something else entirely.
+    run("catalog/products/B%2F01")
+
+    assert client.asked["path"] == "catalog/products/B%2F01"
+
+
+def test_a_header_reaches_the_request(client):
+    run("library", "-H", "Accept-Language: en-US")
+
+    assert client.asked["headers"] == [("Accept-Language", "en-US")]
+
+
+def test_headers_may_repeat_and_are_trimmed(client):
+    # Both go out: http allows a name more than once, and a dict here
+    # would have kept the last.
+    run("library", "-H", "X-One:  a ", "-H", "X-One: b")
+
+    assert client.asked["headers"] == [("X-One", "a"), ("X-One", "b")]
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Authorization: Bearer x",
+        "x-adp-token: stolen",
+        "X-Amz-Access-Token: stolen",
+        "Host: elsewhere",
+        "content-type: text/xml",
+        "Content-Length: 0",
+    ],
+)
+def test_the_headers_that_carry_the_authentication_are_refused(client, header):
+    result = run("library", "-H", header)
+
+    assert result.exit_code == 2
+    assert "cannot be given here" in result.stderr
+    assert client.asked is None
+
+
+def test_a_header_needs_a_colon(client):
+    result = run("library", "-H", "nonsense")
+
+    assert result.exit_code == 2
+    assert "is not 'Name: value'" in result.stderr
+
+
+def test_the_headers_can_be_written_to_a_file(client, tmp_path):
+    # `continuation-token` and `total-count` only come back as headers, so
+    # this is how a script pages through a long answer.
+    path = tmp_path / "head.txt"
+
+    result = run("library", "-D", str(path))
+
+    assert result.exit_code == 0
+    written = path.read_text(encoding="utf-8")
+    assert written.startswith("HTTP/1.1 200 OK\n")
+    assert "content-type: application/json" in written
+    assert json.loads(result.stdout) == {"items": [{"asin": "B01"}]}
+
+
+def test_the_headers_are_written_even_when_the_call_failed(monkeypatch, tmp_path):
+    # A failed call is exactly when somebody wants to see what came back.
+    denied = httpx.Response(
+        429,
+        json={"message": "slow down"},
+        headers={"retry-after": "30"},
+        request=httpx.Request("GET", "https://api.audible.de/1.0/library"),
+    )
+    fake = FakeClient(response=denied)
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+    path = tmp_path / "head.txt"
+
+    result = run("library", "-D", str(path))
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "retry-after: 30" in path.read_text(encoding="utf-8")
+
+
+class NoAuth(httpx.Auth):
+    """Stands in for the Authenticator, which the real client insists on."""
+
+    def auth_flow(self, request):
+        yield request
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["library"], "https://api.audible.de/1.0/library"),
+        (
+            ["library", "-q", "num_results=5"],
+            "https://api.audible.de/1.0/library?num_results=5",
+        ),
+        (["library?num_results=5"], "https://api.audible.de/1.0/library?num_results=5"),
+        (
+            ["library?num_results=5", "-q", "rg=media"],
+            "https://api.audible.de/1.0/library?num_results=5&rg=media",
+        ),
+        (
+            ["library?a=1&a=2", "-q", "a=3"],
+            "https://api.audible.de/1.0/library?a=1&a=2&a=3",
+        ),
+        (["library?flag"], "https://api.audible.de/1.0/library?flag="),
+    ],
+)
+def test_the_url_that_actually_goes_out(monkeypatch, args, expected):
+    # Through the real client, not a stand-in: httpx replaces the URL query
+    # with whatever `params` says, so a query written into the endpoint only
+    # survives because the command takes it apart and sends it along. A fake
+    # client cannot show that.
+    sent = {}
+
+    def handler(request):
+        sent["url"] = str(request.url)
+        return httpx.Response(200, json={})
+
+    def get_client(self, **kw):
+        return AsyncClient(
+            auth=NoAuth(),
+            country_code=kw.get("country_code") or "de",
+            transport=httpx.MockTransport(handler),
+        )
+
+    monkeypatch.setattr(Session, "get_client", get_client)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run(*args)
+
+    assert result.exit_code == 0, result.exception
+    assert sent["url"] == expected
+
+
+def test_a_body_can_come_from_a_file(client, tmp_path):
+    # Some bodies are long enough that a shell argument is the wrong place.
+    path = tmp_path / "body.json"
+    path.write_text('{"asins": ["B01", "B02"]}', encoding="utf-8")
+
+    run("wishlist", "-m", "POST", "--body-file", str(path))
+
+    assert client.asked["body"] == {"asins": ["B01", "B02"]}
+
+
+def test_a_body_can_come_through_a_pipe(client):
+    run("wishlist", "-m", "POST", "--body-file", "-", input='{"asin": "B01"}')
+
+    assert client.asked["body"] == {"asin": "B01"}
+
+
+def test_a_file_that_is_not_json_says_which_file(client, tmp_path):
+    path = tmp_path / "body.json"
+    path.write_text("{broken}", encoding="utf-8")
+
+    result = run("wishlist", "-m", "POST", "--body-file", str(path))
+
+    assert result.exit_code == 2
+    assert "body.json is not valid JSON" in result.stderr
+    assert client.asked is None
+
+
+def test_the_two_ways_of_giving_a_body_exclude_each_other(client, tmp_path):
+    path = tmp_path / "body.json"
+    path.write_text("{}", encoding="utf-8")
+
+    result = run("wishlist", "-m", "POST", "-b", "{}", "--body-file", str(path))
+
+    assert result.exit_code == 2
+    assert "cannot both be given" in result.stderr
+    assert client.asked is None

--- a/tests/test_cmd_api.py
+++ b/tests/test_cmd_api.py
@@ -304,9 +304,7 @@ def test_the_answer_can_go_to_a_file(client, tmp_path):
     result = run("library", "-o", str(path))
 
     assert result.exit_code == 0
-    assert json.loads(path.read_text(encoding="utf-8")) == {
-        "items": [{"asin": "B01"}]
-    }
+    assert json.loads(path.read_text(encoding="utf-8")) == {"items": [{"asin": "B01"}]}
     assert result.stdout == ""
 
 


### PR DESCRIPTION
`audible api` is for the Audible API and for json. This narrows it to
that, and keeps every part of a request the caller wrote.

## What was wrong

Reproduced against `master`:

| Command | Was |
|---|---|
| `api "library?num_results=5"` | asked for the whole library — the query was erased |
| `api library -p asins=A -p asins=B` | asked after one book |
| `api library -p k=a=b` / `-p broken` / `-b '{'` | traceback, exit 3 |
| `api library -i vier` | exit 0, every nested line prefixed with `vier` |
| `api library -f dict -o out.json` | `TypeError`, exit 3 |
| `api https://foreign.host/collect` | sent as given, signed for that host |
| a 200 that is not json | quoted into a json string, exit 0 |
| `api library --timeout 60` | gave up after the library's 10 seconds |

The query was erased because the command always passed `params={}`, and
httpx replaces the url query with whatever `params` says rather than
merging the two.

## What it does now

The endpoint is a **path**. The marketplace comes from the profile or
`--country-code`, so it is decided in one place, and a url is refused
before any credentials are loaded. A query written into the path and one
given with `--query` add up, repeats included. The answer has to be
json, and json is what stdout carries.

What the command cannot send it refuses rather than drops: a body on a
`GET` or a `DELETE`, a body of `null`, `NaN` and `Infinity`, an endpoint
that names nothing, a fragment.

New: `--header/-H` (repeatable, the same name twice included; the
headers that carry the authentication or describe the body are refused),
`--body-file` (a file, or `-` for standard input), `--dump-header/-D`
(the status line and the response headers, written even when the call
failed — `total-count` and `continuation-token` live there).

`--param` is now `--query/-q` and says it is old, which gives `-p` back
to the group, where it is the password. `--format` takes only `json` and
says it is on its way out; `-f dict` printed a Python literal that no
json reader takes.

## Not covered here

The hosts that are not the API, and answers that are not json, move to
`audible request`, which follows before the release. Nothing is dropped
without a replacement being there.

## Tests

The command had none. 60 now, including one that goes through the real
`AsyncClient` behind a `MockTransport` and reads the url off the
outgoing request — a stand-in client cannot show the httpx behaviour
that erased the query.
