### PR TITLE
fix: encrypt an auth file after the fact, and stop asking for what is thrown away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible manage auth-file encrypt` puts a password on an auth file that has none. Whatever is not given is asked for, so a password need not be typed where the shell keeps it, and a script that passes both options is asked nothing. It says so and changes nothing when the file is not an auth file, when it is encrypted already, or when it has a second name in the file system (#313, #315)
+- `audible manage auth-file encrypt` puts a password on an auth file that has none. Whatever is not given is asked for, so a password need not be typed where the shell keeps it, and a script that passes both options is asked nothing. It says so and changes nothing when the file is not an auth file, when it is encrypted already, or when it has a second name in the file system. The rewritten file keeps the permissions it had, so a decrypted one is as readable to others as it was before it was encrypted (#313, #315)
 - `audible manage auth-file decrypt` takes the password off again, asking and refusing the same way (#313, #315)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Whatever is not given is asked for, so a password need not be typed where the shell keeps it, and a script that passes both options is asked nothing. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313, #315)
+- `audible manage auth-file encrypt` puts a password on an auth file that has none. Whatever is not given is asked for, so a password need not be typed where the shell keeps it, and a script that passes both options is asked nothing. It says so and changes nothing when the file is not an auth file, when it is encrypted already, or when it has a second name in the file system (#313, #315)
+- `audible manage auth-file decrypt` takes the password off again, asking and refusing the same way (#313, #315)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Neither asks for anything: the file and the password come from the command line, so both can run in a script. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313, #315)
+- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Whatever is not given is asked for, so a password need not be typed where the shell keeps it, and a script that passes both options is asked nothing. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313, #315)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `audible manage auth-file add --external-login` no longer asks for an Audible username and password. The browser does the login, and the two values never reached it (#314)
-- `audible manage auth-file remove` with a wrong password now says the file does not open, instead of a traceback about PKCS7 padding (#313)
-- `audible manage auth-file add` asks whether the auth file should have a password. The option was there but was never offered, so anyone going through the questions got an unencrypted file, while `quickstart` asked. A script that passed every other option now has to pass `--password ''` as well, to say that it wants none (#313)
+- `audible manage auth-file add --external-login` no longer asks for an Audible username and password. The browser does the login, and the two values never reached it (#314, #315)
+- `audible manage auth-file remove` with a wrong password now says the file does not open, instead of a traceback about PKCS7 padding (#313, #315)
+- `audible manage auth-file add` asks whether the auth file should have a password. The option was there but was never offered, so anyone going through the questions got an unencrypted file, while `quickstart` asked. A script that passed every other option now has to pass `--password ''` as well, to say that it wants none (#313, #315)
 - `--version` no longer exits 1 with the error glued to the version when the update check cannot reach GitHub (#309)
 - A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Neither asks for anything: the file and the password come from the command line, so both can run in a script. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313)
+- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Neither asks for anything: the file and the password come from the command line, so both can run in a script. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313, #315)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `audible manage auth-file add --external-login` no longer asks for an Audible username and password. The browser does the login, and the two values never reached it (#314)
+- `audible manage auth-file remove` with a wrong password now says the file does not open, instead of a traceback about PKCS7 padding (#313)
+- `audible manage auth-file add` asks whether the auth file should have a password. The option was there but was never offered, so anyone going through the questions got an unencrypted file, while `quickstart` asked. A script that passed every other option now has to pass `--password ''` as well, to say that it wants none (#313)
 - `--version` no longer exits 1 with the error glued to the version when the update check cannot reach GitHub (#309)
 - A podcast episode that is already downloaded no longer costs a voucher on every run (#299)
 - A cover size a title does not offer is reported as a warning, not an error (#300)
@@ -27,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `audible manage auth-file encrypt` puts a password on an auth file that has none, and `audible manage auth-file decrypt` takes it off again. Neither asks for anything: the file and the password come from the command line, so both can run in a script. Either says so and changes nothing when the file is not an auth file, when it is one but of the wrong shape, or when it has a second name in the file system (#313)
 - `--log-file PATH` writes the log to a file as well, with timestamp, module and line (#306)
 - `NO_COLOR` and `FORCE_COLOR` decide whether diagnostics are coloured (#306)
 - Standalone builds for arm64 on Linux and Windows; the macOS build stays Apple silicon only (#296)

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -151,7 +151,13 @@ def check_if_auth_file_not_exists(session, ctx, param, value):
 )
 @click.option(
     "--password", "-p",
-    help="The optional password for the auth file."
+    prompt="Please enter a password for the auth file (or enter for none)",
+    default="",
+    show_default=False,
+    hide_input=True,
+    confirmation_prompt=True,
+    help="The optional password for the auth file.",
+    cls=DialogOption,
 )
 @click.option(
     "--audible-username", "-au",
@@ -195,7 +201,7 @@ def add_auth_file(
         username=audible_username,
         password=audible_password,
         country_code=country_code,
-        file_password=password,
+        file_password=password or None,
         external_login=external_login,
         with_username=with_username
     )

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -6,7 +6,7 @@ import click
 from click import echo
 from tabulate import tabulate
 
-from .._dialog import DialogOption
+from .._dialog import DialogOption, ask
 from ..constants import AVAILABLE_MARKETPLACES
 from ..decorators import pass_session
 from ..exceptions import AudibleCliException
@@ -166,17 +166,13 @@ def check_if_auth_file_not_exists(session, ctx, param, value):
 )
 @click.option(
     "--audible-username", "-au",
-    prompt="Please enter the audible username",
-    help="The audible username to authenticate.",
-    cls=DialogOption,
+    help="The audible username to authenticate. Asked for unless "
+         "--external-login says a browser will do it.",
 )
 @click.option(
     "--audible-password", "-ap",
-    hide_input=True,
-    confirmation_prompt=True,
-    prompt="Please enter the password for the audible user",
-    help="The password for the audible user.",
-    cls=DialogOption,
+    help="The password for the audible user. Asked for unless "
+         "--external-login says a browser will do it.",
 )
 @click.option(
     "--country-code", "-cc",
@@ -201,6 +197,20 @@ def add_auth_file(
         audible_password, country_code, external_login, with_username
 ):
     """Register a new device and add an auth file to config dir."""
+    # `--external-login` hands the login to a browser, which asks for
+    # itself. The two values below never reach it, so asking for them
+    # here would be asking for something to throw away.
+    if not external_login:
+        if audible_username is None:
+            audible_username = ask("Please enter the audible username")
+
+        if audible_password is None:
+            audible_password = ask(
+                "Please enter the password for the audible user",
+                hide_input=True,
+                confirmation_prompt=True
+            )
+
     build_auth_file(
         filename=session.config.dirname / auth_file,
         username=audible_username,

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -14,6 +14,7 @@ from ..utils import (
     build_auth_file,
     detect_auth_file,
     read_auth_file,
+    read_auth_text,
     rewrite_auth_file,
 )
 
@@ -336,7 +337,7 @@ def encrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
             f"give it another password."
         )
 
-    rewrite_auth_file(read_auth_file(auth_file), auth_file, password)
+    rewrite_auth_file(auth_file, read_auth_text(auth_file, shape), password)
     logger.info("%s is encrypted now", auth_file.name)
 
 
@@ -373,5 +374,7 @@ def decrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
     if shape == "plain":
         raise AudibleCliException(f"{auth_file.name} is not encrypted")
 
-    rewrite_auth_file(read_auth_file(auth_file, password), auth_file, None)
+    text = read_auth_text(auth_file, shape, password)
+
+    rewrite_auth_file(auth_file, text, None)
     logger.info("%s is not encrypted any more", auth_file.name)

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -302,23 +302,27 @@ def check_password_is_not_empty(ctx, param, value):
 @click.option(
     "--auth-file", "-f",
     type=click.Path(exists=False, file_okay=True),
-    required=True,
+    prompt="Please enter name for the auth file",
     callback=check_if_auth_file_exists,
-    help="The auth file name (without dir) to encrypt."
+    help="The auth file name (without dir) to encrypt.",
+    cls=DialogOption,
 )
 @click.option(
     "--password", "-p",
-    required=True,
+    prompt="Please enter a password for the auth file",
+    hide_input=True,
+    confirmation_prompt=True,
     callback=check_password_is_not_empty,
-    help="The password to encrypt the auth file with."
+    help="The password to encrypt the auth file with.",
+    cls=DialogOption,
 )
 def encrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
     """Encrypt an auth file that has no password yet.
 
-    Nothing is asked for here. Both the file and the password come from
-    the command line, so this runs where nobody is watching -- which
-    also means the password is in the shell history and, while the
-    command runs, in the process list.
+    Whatever is not given is asked for, so a password need not be typed
+    where the shell keeps it. Given as an option, it is in the shell
+    history and, while the command runs, in the process list -- which is
+    the price of running this without anybody watching.
     """
     auth_file = resolve_to_the_real_file(auth_file)
     shape = detect_auth_file(auth_file)
@@ -340,20 +344,25 @@ def encrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
 @click.option(
     "--auth-file", "-f",
     type=click.Path(exists=False, file_okay=True),
-    required=True,
+    prompt="Please enter name for the auth file",
     callback=check_if_auth_file_exists,
-    help="The auth file name (without dir) to decrypt."
+    help="The auth file name (without dir) to decrypt.",
+    cls=DialogOption,
 )
 @click.option(
     "--password", "-p",
-    required=True,
+    prompt="Please enter the password of the auth file",
+    hide_input=True,
     callback=check_password_is_not_empty,
-    help="The password the auth file has."
+    help="The password the auth file has.",
+    cls=DialogOption,
 )
 def decrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
     """Take the password off an auth file.
 
-    Nothing is asked for here, the same way `encrypt` asks for nothing.
+    Whatever is not given is asked for, the same way `encrypt` asks. The
+    password is not repeated back here: a wrong one cannot destroy
+    anything, it only fails to open the file.
     """
     auth_file = resolve_to_the_real_file(auth_file)
     shape = detect_auth_file(auth_file)

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -3,14 +3,13 @@ import os
 import pathlib
 
 import click
-from audible import Authenticator
 from click import echo
 from tabulate import tabulate
 
 from .._dialog import DialogOption
 from ..constants import AVAILABLE_MARKETPLACES
 from ..decorators import pass_session
-from ..utils import build_auth_file
+from ..utils import build_auth_file, read_auth_file
 
 
 logger = logging.getLogger("audible_cli.cmds.cmd_manage")
@@ -231,7 +230,7 @@ def check_if_auth_file_exists(session, ctx, param, value):
 )
 def remove_auth_file(auth_file, password):
     """Deregister a device and remove auth file from config dir."""
-    auth = Authenticator.from_file(auth_file, password)
+    auth = read_auth_file(auth_file, password)
     device_name = auth.device_info["device_name"]
     auth.refresh_access_token()
     auth.deregister_device()

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -156,7 +156,7 @@ def check_if_auth_file_not_exists(session, ctx, param, value):
 )
 @click.option(
     "--password", "-p",
-    prompt="Please enter a password for the auth file (or enter for none)",
+    prompt="A password for the auth file, or nothing for none",
     default="",
     show_default=False,
     hide_input=True,

--- a/src/audible_cli/cmds/cmd_manage.py
+++ b/src/audible_cli/cmds/cmd_manage.py
@@ -9,7 +9,13 @@ from tabulate import tabulate
 from .._dialog import DialogOption
 from ..constants import AVAILABLE_MARKETPLACES
 from ..decorators import pass_session
-from ..utils import build_auth_file, read_auth_file
+from ..exceptions import AudibleCliException
+from ..utils import (
+    build_auth_file,
+    detect_auth_file,
+    read_auth_file,
+    rewrite_auth_file,
+)
 
 
 logger = logging.getLogger("audible_cli.cmds.cmd_manage")
@@ -237,3 +243,116 @@ def remove_auth_file(auth_file, password):
     logger.info("%s deregistered", device_name)
     auth_file.unlink()
     logger.info("%s removed from config dir", auth_file)
+
+
+def resolve_to_the_real_file(auth_file: pathlib.Path) -> pathlib.Path:
+    """Find the file that actually holds the credentials.
+
+    A rewrite replaces a name with a new file. Given a symlink, that
+    would put the new file where the link was and leave the credentials
+    it pointed at untouched, while the command reported success -- so
+    the link is followed first. A second hard link cannot be dealt with
+    the same way, because every other name would keep pointing at the
+    old content; that one is refused.
+
+    Args:
+        auth_file: The name that was given.
+
+    Returns:
+        The file it stands for.
+
+    Raises:
+        AudibleCliException: If the file has more than one name.
+    """
+    target = auth_file.resolve()
+
+    if target.stat().st_nlink > 1:
+        raise AudibleCliException(
+            f"{auth_file.name} has more than one name in the file system, "
+            f"and rewriting it would leave the credentials readable under "
+            f"the others"
+        )
+
+    return target
+
+
+def check_password_is_not_empty(ctx, param, value):
+    """Refuse an empty password, which would not encrypt anything.
+
+    `required=True` only asks for the option to be there. An empty value
+    passes it, and would then read as "no password" further down and
+    write the file in the open while reporting success.
+    """
+    if not value:
+        raise click.BadParameter("a password cannot be empty")
+    return value
+
+
+@manage_auth_files.command("encrypt")
+@click.option(
+    "--auth-file", "-f",
+    type=click.Path(exists=False, file_okay=True),
+    required=True,
+    callback=check_if_auth_file_exists,
+    help="The auth file name (without dir) to encrypt."
+)
+@click.option(
+    "--password", "-p",
+    required=True,
+    callback=check_password_is_not_empty,
+    help="The password to encrypt the auth file with."
+)
+def encrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
+    """Encrypt an auth file that has no password yet.
+
+    Nothing is asked for here. Both the file and the password come from
+    the command line, so this runs where nobody is watching -- which
+    also means the password is in the shell history and, while the
+    command runs, in the process list.
+    """
+    auth_file = resolve_to_the_real_file(auth_file)
+    shape = detect_auth_file(auth_file)
+
+    if shape is None:
+        raise AudibleCliException(f"{auth_file.name} is not an auth file")
+
+    if shape != "plain":
+        raise AudibleCliException(
+            f"{auth_file.name} is encrypted already. Decrypt it first to "
+            f"give it another password."
+        )
+
+    rewrite_auth_file(read_auth_file(auth_file), auth_file, password)
+    logger.info("%s is encrypted now", auth_file.name)
+
+
+@manage_auth_files.command("decrypt")
+@click.option(
+    "--auth-file", "-f",
+    type=click.Path(exists=False, file_okay=True),
+    required=True,
+    callback=check_if_auth_file_exists,
+    help="The auth file name (without dir) to decrypt."
+)
+@click.option(
+    "--password", "-p",
+    required=True,
+    callback=check_password_is_not_empty,
+    help="The password the auth file has."
+)
+def decrypt_auth_file(auth_file: pathlib.Path, password: str) -> None:
+    """Take the password off an auth file.
+
+    Nothing is asked for here, the same way `encrypt` asks for nothing.
+    """
+    auth_file = resolve_to_the_real_file(auth_file)
+    shape = detect_auth_file(auth_file)
+
+    if shape is None:
+        raise AudibleCliException(f"{auth_file.name} is not an auth file")
+
+    if shape == "plain":
+        raise AudibleCliException(f"{auth_file.name} is not encrypted")
+
+    rewrite_auth_file(read_auth_file(auth_file, password), auth_file, None)
+    logger.info("%s is not encrypted any more", auth_file.name)

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -15,7 +15,7 @@ import aiofiles
 import click
 import httpx
 from audible import Authenticator
-from audible.aescipher import BLOCK_SIZE
+from audible.aescipher import BLOCK_SIZE, AESCipher
 from audible.client import raise_for_status
 from audible.exceptions import (
     NetworkError,
@@ -370,9 +370,64 @@ def flush_directory(directory: pathlib.Path) -> None:
         os.close(handle)
 
 
-def rewrite_auth_file(
-        auth: Authenticator,
+def read_auth_text(
         auth_file: pathlib.Path,
+        shape: str,
+        password: str | None = None
+) -> str:
+    """Read what an auth file holds, decrypting it on the way if need be.
+
+    The text is taken as it stands rather than through `Authenticator`.
+    Putting a password on a file is a thing done to the file, not to the
+    account behind it: what comes back out is what went in, down to the
+    key order and the fields the library has no name for, and nothing
+    here has to hold an opinion on whether the contents would make a
+    working login.
+
+    Args:
+        auth_file: The file to read.
+        shape: What `detect_auth_file` said it is.
+        password: Its password, if it has one.
+
+    Returns:
+        The text the file holds.
+
+    Raises:
+        AudibleCliException: If the file does not open.
+    """
+    # Imported here rather than at the top: `exceptions` takes
+    # `parse_api_datetime` from this module, so the two cannot both
+    # import each other while they are being read.
+    from .exceptions import AudibleCliException  # noqa: PLC0415
+
+    if shape == "plain":
+        return auth_file.read_text(encoding="utf-8")
+
+    try:
+        text = AESCipher(password or "").from_file(auth_file, encryption=shape)
+    except Exception as error:
+        raise AudibleCliException(
+            f"{auth_file.name} does not open: {error}"
+        ) from error
+
+    try:
+        document = json.loads(text)
+    except ValueError as error:
+        raise AudibleCliException(
+            f"{auth_file.name} opened, but holds no json"
+        ) from error
+
+    if not any(all(document.get(f) for f in pair) for pair in AUTH_FILE_FIELDS):
+        raise AudibleCliException(
+            f"{auth_file.name} opened, but holds no credentials"
+        )
+
+    return text
+
+
+def rewrite_auth_file(
+        auth_file: pathlib.Path,
+        text: str,
         password: str | None
 ) -> None:
     """Write an auth file again, with or without a password.
@@ -389,8 +444,8 @@ def rewrite_auth_file(
     credentials where they are.
 
     Args:
-        auth: What was read from the file.
-        auth_file: Where it came from, and goes back to.
+        auth_file: The file to write.
+        text: What it is to hold.
         password: What to encrypt with, or None to leave it in the open.
     """
     handle, name = tempfile.mkstemp(
@@ -401,14 +456,11 @@ def rewrite_auth_file(
 
     try:
         if password:
-            auth.to_file(
-                written,
-                password=password,
-                encryption=DEFAULT_AUTH_FILE_ENCRYPTION,
-                set_default=False
+            AESCipher(password).to_file(
+                text, written, encryption=DEFAULT_AUTH_FILE_ENCRYPTION
             )
         else:
-            auth.to_file(written, encryption=False, set_default=False)
+            written.write_text(text, encoding="utf-8")
 
         shutil.copymode(auth_file, written)
 

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -326,10 +326,12 @@ def detect_auth_file(auth_file: pathlib.Path) -> str | None:
         document = None
 
     if isinstance(document, dict):
-        if {"salt", "iv", "ciphertext", "info"} <= document.keys():
+        # `info` is written as well, but only these three are read
+        # back, so a file without it still opens.
+        if {"salt", "iv", "ciphertext"} <= document.keys():
             return "json"
 
-        if any(all(f in document for f in pair) for pair in AUTH_FILE_FIELDS):
+        if any(all(document.get(f) for f in pair) for pair in AUTH_FILE_FIELDS):
             return "plain"
 
         return None
@@ -342,6 +344,30 @@ def detect_auth_file(auth_file: pathlib.Path) -> str | None:
     blocks = len(data) >= 3 * BLOCK_SIZE and len(data) % BLOCK_SIZE == 0
 
     return "bytes" if header and blocks else None
+
+
+def flush_directory(directory: pathlib.Path) -> None:
+    """Put a directory's own contents on disk.
+
+    A rename is a change to the directory, and is only durable once the
+    directory is written out. Not every platform lets one be opened for
+    that; where it cannot, what survives a power cut is the file as it
+    was before, which is the safe half of the answer anyway.
+
+    Args:
+        directory: The directory to flush.
+    """
+    try:
+        handle = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+
+    try:
+        os.fsync(handle)
+    except OSError:
+        pass
+    finally:
+        os.close(handle)
 
 
 def rewrite_auth_file(
@@ -393,6 +419,7 @@ def rewrite_auth_file(
             os.fsync(file.fileno())
 
         os.replace(written, auth_file)
+        flush_directory(auth_file.parent)
     finally:
         written.unlink(missing_ok=True)
 

--- a/src/audible_cli/utils.py
+++ b/src/audible_cli/utils.py
@@ -1,9 +1,13 @@
 import asyncio
 import csv
 import io
+import json
 import logging
+import os
 import pathlib
 import random
+import shutil
+import tempfile
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
 
@@ -11,6 +15,7 @@ import aiofiles
 import click
 import httpx
 from audible import Authenticator
+from audible.aescipher import BLOCK_SIZE
 from audible.client import raise_for_status
 from audible.exceptions import (
     NetworkError,
@@ -281,6 +286,158 @@ def build_auth_file(
         filename.parent.mkdir(parents=True)
 
     auth.to_file(**file_options)
+
+
+#: What makes a document an auth file: the registration of a device, or
+#: the tokens a login leaves behind. One pair is enough.
+AUTH_FILE_FIELDS = (
+    ("adp_token", "device_private_key"),
+    ("access_token", "refresh_token"),
+)
+
+#: The older encryption writes the number of kdf iterations between two
+#: of these, and that header is what marks the format.
+SALT_MARKER = b"$"
+
+
+def detect_auth_file(auth_file: pathlib.Path) -> str | None:
+    """Say which shape a file has, if it has one of the three at all.
+
+    The library's own `detect_file_encryption` decides this from a
+    single key and a single exception: a json document holding
+    `adp_token` is unencrypted, one holding `ciphertext` is encrypted as
+    json, and anything that is not json at all is called encrypted as
+    bytes. So a file of nonsense reads as encrypted, and a json document
+    of something else reads as neither -- and both then reach a command
+    that would write over them.
+
+    Args:
+        auth_file: The file to look at.
+
+    Returns:
+        `"plain"`, `"json"`, `"bytes"`, or None for a file that is none
+        of the three.
+    """
+    data = auth_file.read_bytes()
+
+    try:
+        document = json.loads(data)
+    except ValueError:
+        document = None
+
+    if isinstance(document, dict):
+        if {"salt", "iv", "ciphertext", "info"} <= document.keys():
+            return "json"
+
+        if any(all(f in document for f in pair) for pair in AUTH_FILE_FIELDS):
+            return "plain"
+
+        return None
+
+    # The bytes format opens with the salt header: the marker, the
+    # number of kdf iterations as a big-endian word, the marker again.
+    # An iv and whole cipher blocks follow it, so the length answers the
+    # rest of the question.
+    header = data[:1] == SALT_MARKER and data[3:4] == SALT_MARKER
+    blocks = len(data) >= 3 * BLOCK_SIZE and len(data) % BLOCK_SIZE == 0
+
+    return "bytes" if header and blocks else None
+
+
+def rewrite_auth_file(
+        auth: Authenticator,
+        auth_file: pathlib.Path,
+        password: str | None
+) -> None:
+    """Write an auth file again, with or without a password.
+
+    The file carries the registration of a device, and half of one is
+    only recoverable by registering again. The new content therefore
+    goes to a file beside it and takes its place in a single step,
+    keeping the permissions the old one had. The name of that file is
+    made by `mkstemp`, so two runs at once cannot write to the same one
+    and no file that was already there is overwritten.
+
+    Give it the path a symlink points at, not the link: `os.replace`
+    would put the new file where the link was and leave the old
+    credentials where they are.
+
+    Args:
+        auth: What was read from the file.
+        auth_file: Where it came from, and goes back to.
+        password: What to encrypt with, or None to leave it in the open.
+    """
+    handle, name = tempfile.mkstemp(
+        dir=auth_file.parent, prefix=f"{auth_file.name}.", suffix=".new"
+    )
+    os.close(handle)
+    written = pathlib.Path(name)
+
+    try:
+        if password:
+            auth.to_file(
+                written,
+                password=password,
+                encryption=DEFAULT_AUTH_FILE_ENCRYPTION,
+                set_default=False
+            )
+        else:
+            auth.to_file(written, encryption=False, set_default=False)
+
+        shutil.copymode(auth_file, written)
+
+        # On disk before it takes the old file's place: a power cut after
+        # the rename but before the content is written out would leave
+        # neither the old file nor a readable new one.
+        with written.open("r+b") as file:
+            os.fsync(file.fileno())
+
+        os.replace(written, auth_file)
+    finally:
+        written.unlink(missing_ok=True)
+
+
+def read_auth_file(
+        auth_file: pathlib.Path,
+        password: str | None = None
+) -> Authenticator:
+    """Read an auth file, and say what went wrong rather than raise it.
+
+    Args:
+        auth_file: The file to read.
+        password: Its password, if it has one.
+
+    Returns:
+        What the file holds.
+
+    Raises:
+        AudibleCliException: If the file does not open.
+    """
+    # Imported here rather than at the top: `exceptions` takes
+    # `parse_api_datetime` from this module, so the two cannot both
+    # import each other while they are being read.
+    from .exceptions import AudibleCliException  # noqa: PLC0415
+
+    try:
+        auth = Authenticator.from_file(auth_file, password=password)
+    except Exception as error:
+        # Every shape of wrong file lands here. The library says
+        # `FileEncryptionError` for a missing password, `ValueError` for
+        # a wrong one, and a `TypeError` or a `KeyError` for whichever
+        # field it reads first and does not like.
+        raise AudibleCliException(
+            f"{auth_file.name} does not open: {error}"
+        ) from error
+
+    # A json file of something else entirely reads as an authenticator
+    # with nothing in it. Writing that back would replace a file this
+    # command was never pointed at on purpose.
+    if not any(all(getattr(auth, f) for f in pair) for pair in AUTH_FILE_FIELDS):
+        raise AudibleCliException(
+            f"{auth_file.name} opened, but holds no credentials"
+        )
+
+    return auth
 
 
 class LongestSubString:

--- a/tests/test_cmd_manage.py
+++ b/tests/test_cmd_manage.py
@@ -156,13 +156,15 @@ def test_an_auth_file_can_be_encrypted_after_the_fact(tmp_path, narrating):
 
 
 def test_the_round_trip_changes_nothing(tmp_path):
+    # Byte for byte: what comes back is the text that went in, not a
+    # rendering of what a parser made of it.
     path = auth_file(tmp_path)
-    before = json.loads(path.read_text())
+    before = path.read_text()
 
     manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
     manage(tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD)
 
-    assert json.loads(path.read_text()) == before
+    assert path.read_text() == before
 
 
 def test_an_encrypted_auth_file_can_be_decrypted(tmp_path, narrating):
@@ -394,7 +396,9 @@ def test_the_option_skips_the_prompt(tmp_path):
     assert "password for the auth file" not in result.stderr
 
 
-@pytest.mark.parametrize("breaks", ["audible.Authenticator.to_file", "shutil.copymode"])
+@pytest.mark.parametrize(
+    "breaks", ["audible.aescipher.AESCipher.to_file", "shutil.copymode"]
+)
 def test_a_write_that_fails_leaves_the_auth_file_as_it_was(tmp_path, breaks):
     # The file is the device registration. Writing it in place would put
     # it at risk of every error between the first byte and the last. The
@@ -555,20 +559,52 @@ def test_a_file_that_was_already_there_is_not_overwritten(tmp_path):
     assert detect_auth_file(path) == "json"
 
 
-def test_a_field_of_the_wrong_type_is_refused(tmp_path):
-    # The library validates field by field and raises whatever fits the
-    # field it looked at -- a `TypeError` here, a `ValueError` there.
-    # None of them may reach the user as a traceback.
+def test_a_file_the_library_would_not_load_can_still_be_encrypted(tmp_path):
+    # `website_cookies` of the wrong type makes `Authenticator.from_file`
+    # raise. Encrypting is a thing done to a file, not to an account, so
+    # it does not ask the library what it thinks of the contents.
     profile_config(tmp_path, "one")
     path = tmp_path / "one.json"
-    path.write_text(json.dumps({**FAKE_AUTH, "website_cookies": {"session-id": 123}}))
+    before = json.dumps({**FAKE_AUTH, "website_cookies": {"session-id": 123}})
+    path.write_text(before)
 
-    result = manage(
+    manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+    encrypted = detect_auth_file(path)
+    manage(tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert encrypted == "json"
+    assert path.read_text() == before
+
+
+def test_no_marketplace_has_to_be_known(tmp_path):
+    # Neither command asks which marketplace the file belongs to,
+    # because neither logs in with it. Going back through
+    # `Authenticator` would reintroduce the question, and fail with
+    # `'NoneType' object has no attribute 'country_code'` on a file that
+    # does not answer it.
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    before = json.dumps(
+        {
+            "adp_token": FAKE_AUTH["adp_token"],
+            "device_private_key": FAKE_AUTH["device_private_key"],
+        },
+        indent=4,
+    )
+    path.write_text(before)
+
+    encrypting = manage(
         tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
     )
+    encrypted = detect_auth_file(path)
+    decrypting = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
 
-    assert isinstance(result.exception, AudibleCliException)
-    assert "does not open" in str(result.exception)
+    assert encrypting.exit_code == 0, encrypting.output
+    assert decrypting.exit_code == 0, decrypting.output
+    assert encrypted == "json"
+    assert path.read_text() == before
 
 
 def test_the_older_encryption_is_recognised_and_can_be_taken_off(tmp_path, narrating):

--- a/tests/test_cmd_manage.py
+++ b/tests/test_cmd_manage.py
@@ -1,13 +1,17 @@
+import json
 import logging
 import os
 import pathlib
 from unittest import mock
 
 import pytest
+from audible import Authenticator
 from click.testing import CliRunner
 
 from audible_cli.cmds.cmd_manage import cli
 from audible_cli.config import Session
+from audible_cli.exceptions import AudibleCliException
+from audible_cli.utils import detect_auth_file
 
 
 def test_config_edit_passes_str_path_to_click_edit(tmp_path):
@@ -96,3 +100,481 @@ def test_the_removal_is_told_once_and_on_stderr(tmp_path, narrating):
     assert result.stdout == ""
     assert result.stderr.count("removed from config") == 1
     assert result.stderr.count("Config written to") == 1
+
+
+FILE_PASSWORD = "a password for the test"  # noqa: S105
+AUDIBLE_PASSWORD = "a password for the audible account"  # noqa: S105
+
+FAKE_AUTH = {
+    "website_cookies": {"session-id": "123"},
+    "adp_token": "{enc:AAAA}{key:BBBB}{iv:CCCC}{name:QURQ}{serial:Mg==}",
+    "access_token": "Atna|not-a-real-token",
+    "refresh_token": "Atnr|not-a-real-token",
+    "device_private_key": (
+        "-----BEGIN RSA PRIVATE KEY-----\nnot a key\n-----END RSA PRIVATE KEY-----\n"
+    ),
+    "store_authentication_cookie": {"cookie": "x"},
+    "device_info": {"device_name": "A test device"},
+    "customer_info": {"user_id": "x"},
+    "expires": 9999999999.0,
+    "locale_code": "de",
+    "with_username": False,
+    "activation_bytes": None,
+}
+
+
+def auth_file(tmp_path, name="one.json", password=None):
+    """An auth file holding made-up credentials, encrypted or not."""
+    profile_config(tmp_path, "one")
+    path = tmp_path / name
+    path.write_text(json.dumps(FAKE_AUTH, indent=4))
+
+    if password is not None:
+        auth = Authenticator.from_file(path)
+        auth.to_file(path, password=password, encryption="json", set_default=False)
+
+    return path
+
+
+def manage(tmp_path, *args, **kwargs):
+    session = Session()
+    session._app_dir = tmp_path
+    return CliRunner().invoke(cli, list(args), obj=session, **kwargs)
+
+
+def test_an_auth_file_can_be_encrypted_after_the_fact(tmp_path, narrating):
+    path = auth_file(tmp_path)
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert result.exit_code == 0, result.output
+    assert detect_auth_file(path) == "json"
+    assert result.stdout == ""
+    assert "one.json is encrypted now" in result.stderr
+
+
+def test_the_round_trip_changes_nothing(tmp_path):
+    path = auth_file(tmp_path)
+    before = json.loads(path.read_text())
+
+    manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+    manage(tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert json.loads(path.read_text()) == before
+
+
+def test_an_encrypted_auth_file_can_be_decrypted(tmp_path, narrating):
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+
+    result = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert result.exit_code == 0, result.output
+    assert detect_auth_file(path) == "plain"
+    assert json.loads(path.read_text())["adp_token"] == FAKE_AUTH["adp_token"]
+    assert result.stdout == ""
+    assert "not encrypted any more" in result.stderr
+
+
+def test_encrypting_twice_says_to_decrypt_first(tmp_path):
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+    before = path.read_bytes()
+
+    result = manage(
+        tmp_path,
+        "auth-file",
+        "encrypt",
+        "-f",
+        "one.json",
+        "-p",
+        FILE_PASSWORD + " but different",
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "encrypted already" in str(result.exception)
+    assert path.read_bytes() == before
+
+
+def test_decrypting_what_is_not_encrypted_says_so(tmp_path):
+    path = auth_file(tmp_path)
+    before = path.read_bytes()
+
+    result = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "is not encrypted" in str(result.exception)
+    assert path.read_bytes() == before
+
+
+def test_the_wrong_password_leaves_the_file_alone(tmp_path):
+    # The file is the device registration: a failed attempt may not cost
+    # it, and a wrong password is not a reason to ask for another one.
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+    before = path.read_bytes()
+
+    result = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", "not the password"
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "does not open" in str(result.exception)
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("command", ["encrypt", "decrypt"])
+def test_neither_command_asks_for_anything(tmp_path, command):
+    # They are meant for a script, so a missing option is a usage error
+    # rather than a prompt that would wait for a person.
+    auth_file(tmp_path)
+
+    result = manage(tmp_path, "auth-file", command)
+
+    assert result.exit_code == 2
+    assert "Missing option" in result.stderr
+
+
+def test_the_permissions_survive_the_rewrite(tmp_path):
+    path = auth_file(tmp_path)
+    path.chmod(0o600)
+
+    manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_nothing_is_left_beside_the_file(tmp_path):
+    auth_file(tmp_path)
+
+    manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["config.toml", "one.json"]
+
+
+def test_removing_with_the_wrong_password_says_so(tmp_path):
+    # It used to reach `Authenticator.from_file` unguarded, where a wrong
+    # password is a traceback about PKCS7 padding.
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+
+    result = manage(
+        tmp_path, "auth-file", "remove", "-f", "one.json", "-p", "not the password"
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "does not open" in str(result.exception)
+    assert path.exists()
+
+
+def test_the_prompt_hands_the_password_on(tmp_path):
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-au",
+            "someone",
+            "-ap",
+            "an audible password",
+            "-cc",
+            "de",
+            input=f"{FILE_PASSWORD}\n{FILE_PASSWORD}\n",
+        )
+
+    assert build.call_args.kwargs["file_password"] == FILE_PASSWORD
+
+
+def test_an_empty_answer_leaves_the_auth_file_open(tmp_path):
+    # None rather than the empty string: the option is documented as
+    # optional, and `build_auth_file` takes None for "no encryption".
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        result = manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-au",
+            "someone",
+            "-ap",
+            "an audible password",
+            "-cc",
+            "de",
+            input="\n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert build.call_args.kwargs["file_password"] is None
+    assert "password for the auth file" in result.stderr
+    assert result.stdout == ""
+
+
+def test_the_option_skips_the_prompt(tmp_path):
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        result = manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-p",
+            FILE_PASSWORD,
+            "-au",
+            "someone",
+            "-ap",
+            "an audible password",
+            "-cc",
+            "de",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert build.call_args.kwargs["file_password"] == FILE_PASSWORD
+    assert "password for the auth file" not in result.stderr
+
+
+@pytest.mark.parametrize("breaks", ["audible.Authenticator.to_file", "shutil.copymode"])
+def test_a_write_that_fails_leaves_the_auth_file_as_it_was(tmp_path, breaks):
+    # The file is the device registration. Writing it in place would put
+    # it at risk of every error between the first byte and the last. The
+    # second case gets as far as a written file beside it, which is the
+    # one that has to be cleaned up again.
+    path = auth_file(tmp_path)
+    before = path.read_bytes()
+
+    with mock.patch(breaks, side_effect=OSError("no room")):
+        manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert path.read_bytes() == before
+    assert not (tmp_path / "one.json.new").exists()
+
+
+@pytest.mark.parametrize("command", ["encrypt", "decrypt"])
+def test_an_empty_password_is_refused(tmp_path, command):
+    # `required=True` is happy with "", which would then read as "no
+    # password" and write the file in the open while saying otherwise.
+    path = auth_file(tmp_path)
+    before = path.read_bytes()
+
+    result = manage(tmp_path, "auth-file", command, "-f", "one.json", "-p", "")
+
+    assert result.exit_code == 2
+    assert "cannot be empty" in result.stderr
+    assert path.read_bytes() == before
+
+
+def test_an_external_login_is_not_asked_about_the_account(tmp_path):
+    # The browser does the login, and `from_login_external` is never
+    # handed a username or a password, so asking for them here would be
+    # asking for something to throw away.
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        result = manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-cc",
+            "de",
+            "--external-login",
+            input="\n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "audible username" not in result.stderr
+    assert build.call_args.kwargs["username"] is None
+    assert build.call_args.kwargs["password"] is None
+
+
+def test_a_login_here_is_asked_about_the_account(tmp_path):
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        result = manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-cc",
+            "de",
+            input=f"\n\nsomeone\n{AUDIBLE_PASSWORD}\n{AUDIBLE_PASSWORD}\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert build.call_args.kwargs["username"] == "someone"
+    assert build.call_args.kwargs["password"] == AUDIBLE_PASSWORD
+    assert result.stdout == ""
+
+
+def test_a_symlink_leads_to_the_file_it_points_at(tmp_path, narrating):
+    # Replacing the link would put an encrypted file where the link was
+    # and leave the credentials it pointed at in the open.
+    target = auth_file(tmp_path, name="elsewhere.json")
+    link = tmp_path / "one.json"
+    link.symlink_to(target)
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert result.exit_code == 0, result.output
+    assert link.is_symlink()
+    assert detect_auth_file(target) == "json"
+
+
+def test_a_file_with_a_second_name_is_refused(tmp_path):
+    # The rewrite gives this name a new file. Every other name would
+    # keep pointing at the old, readable one.
+    path = auth_file(tmp_path)
+    os.link(path, tmp_path / "also-one.json")
+    before = path.read_bytes()
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "more than one name" in str(result.exception)
+    assert path.read_bytes() == before
+
+
+def test_json_that_is_not_an_auth_file_is_refused(tmp_path):
+    # It reads as an authenticator with nothing in it, and writing that
+    # back would replace a file nobody meant to point at.
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    path.write_text('{"locale_code": "de"}')
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "is not an auth file" in str(result.exception)
+    assert path.read_text() == '{"locale_code": "de"}'
+
+
+def test_a_file_that_is_not_json_at_all_is_refused(tmp_path):
+    # The library reads anything that is not json as the older bytes
+    # encryption, which would send the user off to decrypt a file of
+    # nonsense. Both commands say what is actually the matter.
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    path.write_text("this is not json")
+
+    encrypting = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+    decrypting = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert "is not an auth file" in str(encrypting.exception)
+    assert "is not an auth file" in str(decrypting.exception)
+    assert path.read_text() == "this is not json"
+
+
+def test_a_file_that_was_already_there_is_not_overwritten(tmp_path):
+    # The temporary name used to be `<name>.new`, which would have taken
+    # this file with it.
+    path = auth_file(tmp_path)
+    bystander = tmp_path / "one.json.new"
+    bystander.write_text("someone else's file")
+
+    manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+
+    assert bystander.read_text() == "someone else's file"
+    assert detect_auth_file(path) == "json"
+
+
+def test_a_field_of_the_wrong_type_is_refused(tmp_path):
+    # The library validates field by field and raises whatever fits the
+    # field it looked at -- a `TypeError` here, a `ValueError` there.
+    # None of them may reach the user as a traceback.
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    path.write_text(json.dumps({**FAKE_AUTH, "website_cookies": {"session-id": 123}}))
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "does not open" in str(result.exception)
+
+
+def test_the_older_encryption_is_recognised_and_can_be_taken_off(tmp_path, narrating):
+    # `audible` wrote auth files as raw bytes before it wrote them as
+    # json. They are not json at all, so only their salt header tells
+    # them apart from a file of nonsense.
+    path = auth_file(tmp_path)
+    auth = Authenticator.from_file(path)
+    auth.to_file(path, password=FILE_PASSWORD, encryption="bytes", set_default=False)
+
+    encrypting = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+    decrypting = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert "encrypted already" in str(encrypting.exception)
+    assert decrypting.exit_code == 0, decrypting.output
+    assert json.loads(path.read_text())["adp_token"] == FAKE_AUTH["adp_token"]
+
+
+def test_a_file_holding_only_tokens_counts_as_an_auth_file(tmp_path):
+    # A login that registered no device leaves these two behind, and
+    # they are as much an auth file as a registration is.
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": FAKE_AUTH["access_token"],
+                "refresh_token": FAKE_AUTH["refresh_token"],
+                "locale_code": "de",
+                "expires": FAKE_AUTH["expires"],
+            }
+        )
+    )
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert result.exit_code == 0, result.output
+    assert detect_auth_file(path) == "json"
+
+
+@pytest.mark.parametrize(
+    ("content", "shape"),
+    [
+        (b"$\x03\xe8$" + b"x" * 44, "bytes"),
+        (b"$\x03\xe8$too short", None),
+        (b"y" * 48, None),
+        (b"this is not json", None),
+        (b"", None),
+        (b"[1, 2, 3]", None),
+    ],
+)
+def test_the_older_format_is_told_apart_from_nonsense(tmp_path, content, shape):
+    # Its salt header and its whole cipher blocks are all there is to
+    # go by. The library takes anything that is not json for it.
+    path = tmp_path / "file"
+    path.write_bytes(content)
+
+    assert detect_auth_file(path) == shape

--- a/tests/test_cmd_manage.py
+++ b/tests/test_cmd_manage.py
@@ -399,21 +399,25 @@ def test_a_write_that_fails_leaves_the_auth_file_as_it_was(tmp_path, breaks):
     # The file is the device registration. Writing it in place would put
     # it at risk of every error between the first byte and the last. The
     # second case gets as far as a written file beside it, which is the
-    # one that has to be cleaned up again.
+    # one that has to be cleaned up again -- under whichever name
+    # `mkstemp` gave it, so the whole directory is checked.
     path = auth_file(tmp_path)
     before = path.read_bytes()
 
     with mock.patch(breaks, side_effect=OSError("no room")):
-        manage(tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD)
+        result = manage(
+            tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+        )
 
+    assert result.exit_code != 0
     assert path.read_bytes() == before
-    assert not (tmp_path / "one.json.new").exists()
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["config.toml", "one.json"]
 
 
 @pytest.mark.parametrize("command", ["encrypt", "decrypt"])
 def test_an_empty_password_is_refused(tmp_path, command):
-    # `required=True` is happy with "", which would then read as "no
-    # password" and write the file in the open while saying otherwise.
+    # An empty value passes for a given option, and would then read as
+    # "no password" and write the file in the open while saying so.
     path = auth_file(tmp_path)
     before = path.read_bytes()
 
@@ -629,3 +633,75 @@ def test_the_older_format_is_told_apart_from_nonsense(tmp_path, content, shape):
     path.write_bytes(content)
 
     assert detect_auth_file(path) == shape
+
+
+def test_an_empty_answer_is_asked_again(tmp_path):
+    # A prompt without a default keeps asking while the answer is empty,
+    # so the guard that catches `-p ""` is never reached from here.
+    path = auth_file(tmp_path)
+
+    result = manage(
+        tmp_path,
+        "auth-file",
+        "encrypt",
+        input=f"one.json\n\n{FILE_PASSWORD}\n{FILE_PASSWORD}\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert detect_auth_file(path) == "json"
+
+
+def test_an_empty_password_option_says_no_encryption(tmp_path):
+    # What the changelog tells a script to pass instead of answering the
+    # question it now asks.
+    profile_config(tmp_path, "one")
+
+    with mock.patch("audible_cli.cmds.cmd_manage.build_auth_file") as build:
+        result = manage(
+            tmp_path,
+            "auth-file",
+            "add",
+            "-f",
+            "new.json",
+            "-p",
+            "",
+            "-au",
+            "someone",
+            "-ap",
+            AUDIBLE_PASSWORD,
+            "-cc",
+            "de",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert build.call_args.kwargs["file_password"] is None
+    assert "password for the auth file" not in result.stderr
+
+
+def test_an_encrypted_file_without_the_extra_field_is_still_one(tmp_path):
+    # `info` is written along with the encryption, but only `salt`, `iv`
+    # and `ciphertext` are read back, so a file without it opens.
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+    document = json.loads(path.read_text())
+    del document["info"]
+    path.write_text(json.dumps(document))
+
+    result = manage(
+        tmp_path, "auth-file", "decrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert result.exit_code == 0, result.output
+    assert detect_auth_file(path) == "plain"
+
+
+def test_fields_that_are_there_but_empty_are_no_auth_file(tmp_path):
+    profile_config(tmp_path, "one")
+    path = tmp_path / "one.json"
+    path.write_text(json.dumps({"adp_token": None, "device_private_key": None}))
+
+    result = manage(
+        tmp_path, "auth-file", "encrypt", "-f", "one.json", "-p", FILE_PASSWORD
+    )
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "is not an auth file" in str(result.exception)

--- a/tests/test_cmd_manage.py
+++ b/tests/test_cmd_manage.py
@@ -226,16 +226,67 @@ def test_the_wrong_password_leaves_the_file_alone(tmp_path):
     assert path.read_bytes() == before
 
 
+def test_what_is_missing_is_asked_for(tmp_path, narrating):
+    # So that a password need not be typed where the shell keeps it.
+    path = auth_file(tmp_path)
+
+    result = manage(
+        tmp_path,
+        "auth-file",
+        "encrypt",
+        input=f"one.json\n{FILE_PASSWORD}\n{FILE_PASSWORD}\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "name for the auth file" in result.stderr
+    assert "password for the auth file" in result.stderr
+    assert result.stdout == ""
+    assert detect_auth_file(path) == "json"
+
+
+def test_a_password_that_was_asked_for_opens_the_file_again(tmp_path):
+    # Round trip through the questions rather than through the options.
+    path = auth_file(tmp_path)
+    before = json.loads(path.read_text())
+
+    manage(
+        tmp_path,
+        "auth-file",
+        "encrypt",
+        input=f"one.json\n{FILE_PASSWORD}\n{FILE_PASSWORD}\n",
+    )
+    result = manage(
+        tmp_path, "auth-file", "decrypt", input=f"one.json\n{FILE_PASSWORD}\n"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(path.read_text()) == before
+
+
+def test_the_password_is_not_repeated_back_when_taking_it_off(tmp_path):
+    # A wrong one cannot destroy anything, so asking twice would only
+    # be in the way.
+    path = auth_file(tmp_path, password=FILE_PASSWORD)
+
+    result = manage(
+        tmp_path, "auth-file", "decrypt", input=f"one.json\n{FILE_PASSWORD}\n"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Repeat for confirmation" not in result.stderr
+    assert detect_auth_file(path) == "plain"
+
+
 @pytest.mark.parametrize("command", ["encrypt", "decrypt"])
-def test_neither_command_asks_for_anything(tmp_path, command):
-    # They are meant for a script, so a missing option is a usage error
-    # rather than a prompt that would wait for a person.
-    auth_file(tmp_path)
+def test_an_option_that_is_given_is_not_asked_about(tmp_path, command):
+    auth_file(tmp_path, password=None if command == "encrypt" else FILE_PASSWORD)
 
-    result = manage(tmp_path, "auth-file", command)
+    result = manage(
+        tmp_path, "auth-file", command, "-f", "one.json", "-p", FILE_PASSWORD
+    )
 
-    assert result.exit_code == 2
-    assert "Missing option" in result.stderr
+    assert result.exit_code == 0, result.output
+    assert "Please enter" not in result.stderr
 
 
 def test_the_permissions_survive_the_rewrite(tmp_path):


### PR DESCRIPTION
Closes #313
Closes #314

Two reports about the same command, from the same person, in the same week.

## `auth-file add` never offered encryption (#313)

`--password` on `manage auth-file add` has always written an encrypted file. It
was the only option of that command without a prompt, so the questions it asks
— file name, audible user, password, marketplace — walked straight past the one
about encryption, while `quickstart` asks outright. Anyone who used the command
the way it is meant to be used got an auth file in the open and no hint that it
could be otherwise.

It asks now, with an empty answer meaning no password. A script that passed
every other option has to pass `--password ''` as well from here on.

## `auth-file add --external-login` asked for an account it never used (#314)

`build_auth_file` hands the username and password to
`Authenticator.from_login`. With `--external-login` it takes the other branch,
`from_login_external`, which gets the marketplace, `with_username` and the
callback that opens the browser. The two values were asked for and dropped.
They lose their prompts and are asked for in the command instead, only when the
login happens here.

## Encrypting an auth file that already exists (#313)

    audible manage auth-file encrypt -f Second.json
    audible manage auth-file decrypt -f Second.json -p <password>

Whatever is not given is asked for, so a password need not be typed where the
shell keeps it, and a script that passes both options is asked nothing.
`encrypt` repeats the password back, because a typo there would lock the file
with something nobody knows; `decrypt` does not, because a wrong password only
fails to open the file.

Both work on the text of the file through `AESCipher`, not through
`Authenticator`: putting a password on a file is a thing done to the file, not
to the account behind it. A round trip therefore gives back what went in, down
to the key order and any field the library has no name for, and neither command
has to know which marketplace the file belongs to.

An auth file is the registration of a device, and half of one can only be
replaced by registering again. So:

- the new content goes to a name from `mkstemp` in the same directory, is
  flushed to disk, and takes the place of the old file in one step, with the
  permissions it had. The directory is flushed too, because a rename is a
  change to the directory and is only durable once that is written out
- a symlink is followed to what it points at, because replacing the link would
  put an encrypted file where the link was and leave the credentials where
  they are
- a file with a second hard link is refused, because the rewrite would leave
  every other name pointing at the readable one
- an empty password is refused, whether it came from the option or from the
  question. It would read as "no password" further down and write the file in
  the open while reporting success

## Telling an auth file from anything else

`audible.aescipher.detect_file_encryption` decides this from one key and one
exception: a json document holding `adp_token` is unencrypted, one holding
`ciphertext` is encrypted as json, and anything that is not json at all is
called encrypted as bytes. So a file of nonsense reads as encrypted, and a json
document of something else reads as neither — and both then reach a command
that would write over them.

`detect_auth_file` asks what is actually there:

| file | library | here |
|---|---|---|
| plain auth file | `False` | `plain` |
| encrypted as json | `json` | `json` |
| encrypted as bytes | `bytes` | `bytes` |
| some other json | `None` | `None` |
| **a file of nonsense** | **`bytes`** | **`None`** |
| **an empty file** | **`bytes`** | **`None`** |
| **only `access_token` and `refresh_token`** | **`None`** | **`plain`** |

The older format needs no password to recognise: it opens with the salt header
— the marker, the number of kdf iterations as a big-endian word, the marker
again — and what follows is an iv and whole cipher blocks.

## Tests

34 new ones, 42 cases with the parametrised ones counted. Most ask what happens
when something goes wrong and check that the auth file still holds what it
held: a wrong password, an empty one, a file that is not an auth file, one that
is not json at all, a field of the wrong type, a second hard link, a symlink, a
write that fails half way, and a file already sitting where the temporary one
would go.

`detect_auth_file` is exercised directly as well, with the byte strings that
separate the older encryption from a file of nonsense.
