### PR TITLE
feat: add `audible request`, for what the api command is not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `audible request URL` sends one request to any host audible-cli talks to and writes the answer as it arrived. It is for what `audible api` is not: the website, the delivery host and Amazon's CDE service, bodies that are not JSON, and answers that are not either. The host has to be one of `api`, `www`, `cds` or `api.amazon` of a marketplace, or `cde-ta-g7g.amazon.com` — the request carries the credentials of the profile, and a url naming anything else is refused before they are loaded (#NNN)
+- `audible request URL` sends one request to any host audible-cli talks to and writes the answer as it arrived. It is for what `audible api` is not: the website, the delivery host and Amazon's CDE service, bodies that are not JSON, and answers that are not either. The host has to be one of `api`, `www`, `cds` or `api.amazon` of a marketplace, or `cde-ta-g7g.amazon.com` — the request carries the credentials of the profile, and a url naming anything else is refused before they are loaded (#316)
 - `audible api --body-file` reads the request body from a file, or from standard input with `-` (#311)
 - `audible api --header/-H` sends a request header, the same name as often as needed; the headers that carry the authentication or describe the body are refused (#311)
 - `audible api --dump-header/-D` writes the status line and the response headers to a file, which is where `total-count` and `continuation-token` come from (#311)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `audible request URL` sends one request to any host audible-cli talks to and writes the answer as it arrived. It is for what `audible api` is not: the website, the delivery host and Amazon's CDE service, bodies that are not JSON, and answers that are not either. The host has to be one of `api`, `www`, `cds` or `api.amazon` of a marketplace, or `cde-ta-g7g.amazon.com` — the request carries the credentials of the profile, and a url naming anything else is refused before they are loaded (#NNN)
 - `audible api --body-file` reads the request body from a file, or from standard input with `-` (#311)
 - `audible api --header/-H` sends a request header, the same name as often as needed; the headers that carry the authentication or describe the body are refused (#311)
 - `audible api --dump-header/-D` writes the status line and the response headers to a file, which is where `total-count` and `continuation-token` come from (#311)

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ from Audible on a daily schedule using this action.
 ## 🧩 Built-in commands
 
 - **activation-bytes** → Manage DRM activation keys  
-- **api** → Call raw Audible API endpoints  
+- **api** → Call an Audible API endpoint and get JSON back  
+- **request** → Send a request to any host audible-cli talks to  
 - **download** → Download audiobooks  
 - **library** → List, export your library  
 - **wishlist** → Manage wishlist (list, add, remove, export)  
@@ -376,6 +377,39 @@ page. `--dump-header` writes them to a file while stdout stays JSON:
 audible api "library?num_results=50" -D headers.txt > page1.json
 grep continuation-token headers.txt
 ```
+
+### Calling everything else
+
+Audible is not only the API. A companion file comes from the website, the
+audio itself from the delivery host, annotations from Amazon's CDE service.
+`request` is for those: it takes a whole URL, sends the body as it was
+written, and writes the answer as it arrived — bytes, not JSON, and streamed,
+so a file of any size can go through `--output`.
+
+```shell
+audible request https://www.audible.de/companion-file/B07J2M2VC7 -o chapters.json
+audible request https://cde-ta-g7g.amazon.com/FionaCDEServiceEngine/sidecar \
+    -q "type=AUDI" -q "key=B07J2M2VC7" -i
+```
+
+The host has to be one audible-cli itself talks to — `api`, `www`, `cds` and
+`api.amazon` of a marketplace, plus `cde-ta-g7g.amazon.com`. The request
+carries the credentials of the profile, and a URL naming anything else is
+refused before they are loaded. Only https, no port of its own, and no
+name and password written into the URL.
+
+`--include/-i` puts the status line and the response headers in front of the
+body, wherever the body goes — `--output` included. `--dump-header/-D` writes
+them to a file of their own instead. A redirect is shown, not followed. An
+error status ends the command after the answer has been written, so the body
+that explains the refusal is not lost.
+
+The query is sent exactly as it was typed, which matters because a delivery
+URL is signed over those bytes. `--query` appends to it rather than rewriting
+it. The method is whatever the host understands, `PATCH` and `OPTIONS`
+included. A compressed answer arrives unpacked while the headers still say
+what came over the wire, and the client sends `Content-Type: application/json`
+unless `--header` says otherwise.
 
 ---
 

--- a/src/audible_cli/_params.py
+++ b/src/audible_cli/_params.py
@@ -1,0 +1,107 @@
+"""The parameter types `audible api` and `audible request` share.
+
+Both commands take a query and request headers in the same shape, and
+both have to keep a caller out of the headers that carry the
+authentication. What differs is one name: `api` writes the body itself
+and always as JSON, so it owns `content-type` too, while `request` sends
+a body as it was given and leaves the type to whoever wrote it.
+"""
+
+from typing import Any
+
+import click
+
+
+#: Header names neither command lets a caller set. They carry the
+#: authentication, or they frame the message, and both belong to the
+#: client that sends the request.
+AUTHENTICATION_HEADERS = frozenset(
+    {
+        "authorization",
+        "content-length",
+        "host",
+        "proxy-authorization",
+        "transfer-encoding",
+        "x-adp-alg",
+        "x-adp-signature",
+        "x-adp-token",
+        "x-amz-access-token",
+    }
+)
+
+
+class QueryPair(click.ParamType[tuple[str, str]]):
+    """One `key=value` query parameter."""
+
+    name = "key[=value]"
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, str]:
+        """Split at the first `=` only, so a value may contain more.
+
+        A key on its own is a query parameter without a value. httpx
+        sends it as `key=`; a bare `key` cannot be expressed through it.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The key and the value, which may be empty.
+        """
+        key, _, val = value.partition("=")
+
+        if not key:
+            self.fail(f"{value!r} has no name", param, ctx)
+
+        return key, val
+
+
+class HeaderPair(click.ParamType[tuple[str, str]]):
+    """One `Name: value` request header."""
+
+    name = "name: value"
+
+    def __init__(self, refused: frozenset[str]) -> None:
+        """Take the names this command does not hand over.
+
+        Args:
+            refused: Lower-case header names to reject.
+        """
+        self.refused = refused
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, str]:
+        """Split at the first colon, and refuse what is not ours to set.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The header name and its value.
+        """
+        name, sep, val = value.partition(":")
+        name = name.strip()
+
+        if not sep or not name:
+            self.fail(f"{value!r} is not 'Name: value'", param, ctx)
+
+        if name.lower() in self.refused:
+            self.fail(
+                f"{name} is set by audible-cli itself and cannot be given here",
+                param,
+                ctx,
+            )
+
+        return name, val.strip()

--- a/src/audible_cli/cmds/__init__.py
+++ b/src/audible_cli/cmds/__init__.py
@@ -7,6 +7,7 @@ from . import (
     cmd_library,
     cmd_manage,
     cmd_quickstart,
+    cmd_request,
     cmd_wishlist,
 )
 
@@ -18,6 +19,7 @@ cli_cmds = [
     cmd_library.cli,
     cmd_manage.cli,
     cmd_quickstart.cli,
+    cmd_request.cli,
     cmd_wishlist.cli
 ]
 

--- a/src/audible_cli/cmds/cmd_api.py
+++ b/src/audible_cli/cmds/cmd_api.py
@@ -17,6 +17,7 @@ import httpx
 from audible.client import raise_for_status
 from click.core import ParameterSource
 
+from .._params import AUTHENTICATION_HEADERS, HeaderPair, QueryPair
 from ..config import Session
 from ..constants import AVAILABLE_MARKETPLACES
 from ..decorators import pass_session, run_async, timeout_option
@@ -24,6 +25,11 @@ from ..exceptions import AudibleCliException
 
 
 logger = logging.getLogger("audible_cli.cmds.cmd_api")
+
+#: `content-type` joins the shared list here: this command writes the
+#: body itself and always as JSON, so describing it is not the caller's
+#: to do.
+REFUSED_HEADERS = AUTHENTICATION_HEADERS | {"content-type"}
 
 
 class ApiPath(click.ParamType[tuple[str, list[tuple[str, str]]]]):
@@ -91,94 +97,6 @@ class ApiPath(click.ParamType[tuple[str, list[tuple[str, str]]]]):
             self.fail(f"{value!r} has a query parameter without a name", param, ctx)
 
         return path, query
-
-
-class QueryPair(click.ParamType[tuple[str, str]]):
-    """One `key=value` query parameter."""
-
-    name = "key[=value]"
-
-    def convert(
-        self,
-        value: Any,
-        param: click.Parameter | None,
-        ctx: click.Context | None,
-    ) -> tuple[str, str]:
-        """Split at the first `=` only, so a value may contain more.
-
-        A key on its own is a query parameter without a value. httpx sends
-        it as `key=`; a bare `key` cannot be expressed through it.
-
-        Args:
-            value: What was typed.
-            param: The parameter being converted.
-            ctx: The context it belongs to.
-
-        Returns:
-            The key and the value, which may be empty.
-        """
-        key, _, val = value.partition("=")
-
-        if not key:
-            self.fail(f"{value!r} has no name", param, ctx)
-
-        return key, val
-
-
-#: Header names a caller may not set. They carry the authentication, or
-#: they describe a body this command always writes itself: the body is
-#: JSON, and the client says so.
-REFUSED_HEADERS = frozenset(
-    {
-        "authorization",
-        "content-length",
-        "content-type",
-        "host",
-        "proxy-authorization",
-        "transfer-encoding",
-        "x-adp-alg",
-        "x-adp-signature",
-        "x-adp-token",
-        "x-amz-access-token",
-    }
-)
-
-
-class HeaderPair(click.ParamType[tuple[str, str]]):
-    """One `Name: value` request header."""
-
-    name = "name: value"
-
-    def convert(
-        self,
-        value: Any,
-        param: click.Parameter | None,
-        ctx: click.Context | None,
-    ) -> tuple[str, str]:
-        """Split at the first colon, and refuse what is not ours to set.
-
-        Args:
-            value: What was typed.
-            param: The parameter being converted.
-            ctx: The context it belongs to.
-
-        Returns:
-            The header name and its value.
-        """
-        name, sep, val = value.partition(":")
-        name = name.strip()
-
-        if not sep or not name:
-            self.fail(f"{value!r} is not 'Name: value'", param, ctx)
-
-        if name.lower() in REFUSED_HEADERS:
-            self.fail(
-                f"{name} is set by audible-cli itself and cannot be given here",
-                param,
-                ctx,
-            )
-
-        return name, val.strip()
 
 
 def load_json(text: str) -> Any:
@@ -305,7 +223,7 @@ def resolve_body(options: dict[str, Any]) -> tuple[Any, bool]:
 @click.option(
     "--header",
     "-H",
-    type=HeaderPair(),
+    type=HeaderPair(REFUSED_HEADERS),
     multiple=True,
     help="A request header (e.g. 'Accept-Language: en-US'). Repeatable, "
     "including the same name twice. The headers that carry the "

--- a/src/audible_cli/cmds/cmd_request.py
+++ b/src/audible_cli/cmds/cmd_request.py
@@ -1,0 +1,325 @@
+"""Send one request to a host audible-cli talks to, and show the answer.
+
+This is the raw command. The endpoint is a whole URL, the body leaves as
+it was written, and the answer arrives as it was sent: no JSON is parsed,
+no status is second-guessed beyond the exit code. For the Audible API and
+its JSON there is `audible api`, which knows more and asks for less.
+
+The URL has to name a host this tool has business with. The request
+carries the credentials of the profile, so the list of hosts is the list
+of who may be handed them.
+"""
+
+import contextlib
+import logging
+import pathlib
+from typing import Any, BinaryIO
+from urllib.parse import urlencode
+
+import click
+import httpx
+
+from .._params import AUTHENTICATION_HEADERS, HeaderPair, QueryPair
+from ..config import Session
+from ..constants import ALLOWED_REQUEST_HOSTS, CDE_HOST
+from ..decorators import pass_session, run_async, timeout_option
+from ..exceptions import AudibleCliException
+
+
+logger = logging.getLogger("audible_cli.cmds.cmd_request")
+
+
+class RequestUrl(click.ParamType[httpx.URL]):
+    """A whole URL, on a host that may see the credentials."""
+
+    name = "url"
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> httpx.URL:
+        """Refuse what may not be asked, and keep the rest as it is.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The URL, unchanged.
+        """
+        try:
+            url = httpx.URL(value)
+            # Reading the host is what decodes a punycode name, and an
+            # unusable one raises from `idna`, not from httpx.
+            host = url.host
+        except (httpx.InvalidURL, UnicodeError) as error:
+            self.fail(f"{value!r} is not a url: {error}", param, ctx)
+
+        if not url.is_absolute_url:
+            self.fail(
+                f"{value!r} is not a whole url. This command needs the host "
+                f"spelled out; use 'audible api' to send a path to the "
+                f"Audible API.",
+                param,
+                ctx,
+            )
+
+        if url.scheme != "https":
+            self.fail(
+                f"{url.scheme} would carry the credentials in the clear. "
+                f"Only https is sent.",
+                param,
+                ctx,
+            )
+
+        if url.userinfo:
+            self.fail(
+                f"{value!r} carries a name and password of its own, which "
+                f"the profile's credentials would not replace",
+                param,
+                ctx,
+            )
+
+        if url.port is not None:
+            self.fail(f"{host} is not asked on port {url.port}", param, ctx)
+
+        if host not in ALLOWED_REQUEST_HOSTS:
+            self.fail(
+                f"{host} is not a host audible-cli talks to, and the "
+                f"request would hand it the credentials of the profile. "
+                f"Allowed are api, www, cds and api.amazon of a "
+                f"marketplace, and {CDE_HOST}.",
+                param,
+                ctx,
+            )
+
+        return url
+
+
+class HttpMethod(click.ParamType[str]):
+    """The request method, in the upper case the wire uses."""
+
+    name = "method"
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> str:
+        """Take any method a host might understand.
+
+        The list is not fixed here: this command is the raw one, and a
+        host that answers PATCH or OPTIONS is not the client's business.
+
+        Args:
+            value: What was typed.
+            param: The parameter being converted.
+            ctx: The context it belongs to.
+
+        Returns:
+            The method in upper case.
+        """
+        method = value.upper()
+
+        if not method.isalpha():
+            self.fail(f"{value!r} is not an http method", param, ctx)
+
+        return method
+
+
+def extend_query(url: httpx.URL, pairs: tuple[tuple[str, str], ...]) -> httpx.URL:
+    """Add query parameters without disturbing the ones already there.
+
+    Reading a query into pairs and writing it back decodes and encodes
+    it again: `%FF` turns into the replacement character, `%20` into `+`,
+    and a key without a value grows one. The delivery urls this command
+    is for are signed over exactly those bytes, so the new pairs are
+    appended to the raw query instead of merged into a parsed one.
+
+    Args:
+        url: What was asked for.
+        pairs: What `--query` added.
+
+    Returns:
+        The URL with the pairs appended.
+    """
+    raw = url.raw_path
+    separator = b"&" if b"?" in raw else b"?"
+    return url.copy_with(raw_path=raw + separator + urlencode(list(pairs)).encode())
+
+
+def resolve_body(options: dict[str, Any]) -> bytes | None:
+    """Work out the bytes to send as the body.
+
+    A file is read here, before the credentials are. With `-` the body is
+    standard input, and a password prompt would find it exhausted.
+
+    Args:
+        options: The parsed command line.
+
+    Returns:
+        The body, or None when there is none.
+
+    Raises:
+        click.UsageError: If both ways of giving a body were used.
+    """
+    body: str | None = options["body"]
+    body_file: BinaryIO | None = options["body_file"]
+
+    if body is not None and body_file is not None:
+        raise click.UsageError("--body and --body-file cannot both be given")
+
+    if body is not None:
+        return body.encode()
+
+    if body_file is not None:
+        return body_file.read()
+
+    return None
+
+
+def describe(response: httpx.Response) -> str:
+    """Write the status line and the headers the way a dump file has them.
+
+    Args:
+        response: What came back.
+
+    Returns:
+        One line for the status and one for each header.
+    """
+    status = (
+        f"{response.http_version} {response.status_code} {response.reason_phrase}\n"
+    )
+    # `items()` would join a header that came twice into one line, and
+    # two `set-cookie` are not one `set-cookie` with a comma in it.
+    return status + "".join(
+        f"{name}: {value}\n" for name, value in response.headers.multi_items()
+    )
+
+
+@click.command("request")
+@click.argument("url", type=RequestUrl())
+@click.option(
+    "--method",
+    "-m",
+    type=HttpMethod(),
+    default="GET",
+    help="The http request method. Whatever the host understands: GET, "
+    "POST, PUT, DELETE, HEAD, PATCH, OPTIONS.",
+    show_default=True,
+)
+@click.option(
+    "--query",
+    "-q",
+    type=QueryPair(),
+    multiple=True,
+    help="A query parameter (e.g. num_results=5). Only one parameter "
+    "per option. Multiple options of this type are allowed, including "
+    "the same key more than once.",
+)
+@click.option(
+    "--header",
+    "-H",
+    type=HeaderPair(AUTHENTICATION_HEADERS),
+    multiple=True,
+    help="A request header (e.g. 'Accept: text/html'). Repeatable, "
+    "including the same name twice. The headers that carry the "
+    "authentication belong to the client and are refused here.",
+)
+@click.option(
+    "--body",
+    "-b",
+    help="The body to send, as it should arrive. The client says "
+    "`Content-Type: application/json` unless a header says otherwise.",
+)
+@click.option(
+    "--body-file",
+    type=click.File("rb"),
+    help="Read the body from a file, byte for byte. `-` reads it from "
+    "standard input, which then cannot answer a password prompt.",
+)
+@click.option(
+    "--include",
+    "-i",
+    is_flag=True,
+    help="Write the status line and the response headers in front of the "
+    "body, wherever the body goes.",
+)
+@click.option(
+    "--dump-header",
+    "-D",
+    type=click.Path(path_type=pathlib.Path),
+    help="Write the status line and the response headers to a file, also "
+    "when the answer was an error.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=pathlib.Path),
+    help="Write the body to a file, byte for byte.",
+)
+@timeout_option
+@pass_session
+@run_async
+async def cli(session: Session, **options: Any) -> None:
+    """Send one request to a host audible-cli talks to.
+
+    URL is a whole https url, and its host has to be one of those this
+    tool has business with: `api`, `www`, `cds` and `api.amazon` of a
+    marketplace, and the delivery host `cde-ta-g7g.amazon.com`. The
+    request carries the credentials of the profile, which is why the
+    other hosts are refused rather than tried.
+
+    The answer is written as it arrived. A redirect is shown, not
+    followed, and an error status is written out before it ends the
+    command.
+    """
+    url = options["url"]
+    body = resolve_body(options)
+    method = options["method"]
+    headers = list(options["header"]) or None
+    output = options["output"]
+
+    if options["query"]:
+        url = extend_query(url, options["query"])
+
+    client = session.get_client()
+
+    async with client.session:
+        try:
+            # Streamed, so that a file from the delivery host is written
+            # as it arrives rather than held whole in memory first.
+            async with client.raw_request(
+                method, str(url), stream=True, headers=headers, content=body
+            ) as response:
+                head = describe(response)
+
+                if options["dump_header"] is not None:
+                    options["dump_header"].write_text(head, encoding="utf-8")
+                    logger.info("Headers saved to %s", options["dump_header"].resolve())
+
+                if output is None:
+                    sink = contextlib.nullcontext(click.get_binary_stream("stdout"))
+                else:
+                    sink = output.open("wb")
+
+                with sink as answer:
+                    if options["include"]:
+                        answer.write(head.encode("utf-8") + b"\n")
+
+                    async for chunk in response.aiter_bytes():
+                        answer.write(chunk)
+        except httpx.RequestError as error:
+            raise AudibleCliException(f"{method} {url} failed: {error}") from error
+
+    if output is not None:
+        logger.info("Output saved to %s", output.resolve())
+
+    # Written first, then reported: the body of a refusal is what says
+    # why it was refused.
+    if response.is_error:
+        raise AudibleCliException(f"{response.status_code} {response.reason_phrase}")

--- a/src/audible_cli/constants.py
+++ b/src/audible_cli/constants.py
@@ -76,3 +76,30 @@ CDE_FIRST_DELAY: float = 0.5
 AVAILABLE_MARKETPLACES = [
     market["country_code"] for market in LOCALE_TEMPLATES.values()
 ]
+
+#: The hosts of a marketplace that audible-cli has business with: the
+#: API, the website a companion file comes from, the content delivery
+#: the download is redirected to, and the Amazon endpoint that answers
+#: for the user behind the profile.
+MARKETPLACE_HOST_TEMPLATES = (
+    "api.audible.{domain}",
+    "www.audible.{domain}",
+    "cds.audible.{domain}",
+    "api.amazon.{domain}",
+)
+
+#: The one host that is the same for every marketplace. Annotations and
+#: the AAX download url come from it.
+CDE_HOST = "cde-ta-g7g.amazon.com"
+
+#: Where `audible request` may be pointed. The request carries the
+#: credentials of a profile, so this is the list of who is allowed to
+#: receive them.
+ALLOWED_REQUEST_HOSTS = frozenset(
+    {CDE_HOST}
+    | {
+        template.format(domain=market["domain"])
+        for template in MARKETPLACE_HOST_TEMPLATES
+        for market in LOCALE_TEMPLATES.values()
+    }
+)

--- a/tests/test_cmd_request.py
+++ b/tests/test_cmd_request.py
@@ -1,0 +1,594 @@
+"""`audible request` sends what it was given, wherever it is allowed to.
+
+The url decides the host, and only the hosts audible-cli itself talks to
+are allowed, because the request carries the credentials of the profile.
+Body and answer pass through untouched: this is the command for what
+`audible api` cannot do.
+"""
+
+import gzip
+
+import httpx
+import pytest
+from audible.client import AsyncClient
+from click.testing import CliRunner
+
+from audible_cli.cmds import cmd_request
+from audible_cli.config import Session
+from audible_cli.exceptions import AudibleCliException
+
+
+class FakeHTTPSession:
+    """Stands in for the httpx session the client opens."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class Streamed:
+    """What `raw_request(stream=True)` hands back."""
+
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class FakeClient:
+    """Answers every request, and remembers what it was asked."""
+
+    def __init__(self, response=None):
+        self.session = FakeHTTPSession()
+        self.asked = None
+        self._response = response
+
+    def raw_request(self, method, url, **kwargs):
+        self.asked = {
+            "method": method,
+            "url": url,
+            "stream": kwargs.get("stream"),
+            "headers": kwargs.get("headers"),
+            "content": kwargs.get("content"),
+        }
+        response = self._response
+        if response is None:
+            response = httpx.Response(
+                200,
+                content=b"answer",
+                headers={"content-type": "text/plain"},
+                request=httpx.Request(method, url),
+            )
+        return Streamed(response)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A session handing out a client that never reaches the network."""
+    fake = FakeClient()
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+    return fake
+
+
+def answering(monkeypatch, response):
+    """Hand out a client that gives back `response`."""
+    fake = FakeClient(response)
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: fake)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+    return fake
+
+
+def run(*args, **kwargs):
+    return CliRunner().invoke(cmd_request.cli, list(args), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.audible.de/1.0/library",
+        "https://www.audible.co.uk/library/download",
+        "https://cds.audible.com/download",
+        "https://api.amazon.com/user/profile",
+        "https://cde-ta-g7g.amazon.com/FionaCDEServiceEngine/sidecar",
+    ],
+)
+def test_every_host_audible_cli_talks_to_is_allowed(client, url):
+    assert run(url).exit_code == 0
+    assert client.asked["url"] == url
+
+
+def test_a_host_of_its_own_is_refused(client):
+    # The request would hand the profile's credentials to whoever the url
+    # names, so the check comes before a client exists.
+    result = run("https://foreign.host/collect")
+
+    assert result.exit_code == 2
+    assert "not a host audible-cli talks to" in result.stderr
+    assert client.asked is None
+
+
+def test_a_refused_url_never_builds_a_client(monkeypatch):
+    def refuse(self, **kw):
+        raise AssertionError("the credentials were loaded")
+
+    monkeypatch.setattr(Session, "get_client", refuse)
+
+    assert run("https://foreign.host/collect").exit_code == 2
+
+
+def test_plain_http_is_refused(client):
+    result = run("http://api.audible.de/1.0/library")
+
+    assert result.exit_code == 2
+    assert "in the clear" in result.stderr
+    assert client.asked is None
+
+
+def test_a_path_says_which_command_takes_one(client):
+    result = run("1.0/library")
+
+    assert result.exit_code == 2
+    assert "audible api" in result.stderr
+    assert client.asked is None
+
+
+def test_a_port_of_its_own_is_refused(client):
+    result = run("https://api.audible.de:8443/1.0/library")
+
+    assert result.exit_code == 2
+    assert "port 8443" in result.stderr
+
+
+def test_a_name_and_password_in_the_url_are_refused(client):
+    result = run("https://someone:secret@api.audible.de/1.0/library")
+
+    assert result.exit_code == 2
+    assert "name and password of its own" in result.stderr
+
+
+def test_a_url_that_does_not_parse_is_a_usage_error(client):
+    result = run("https://api.audible.de:bad/x")
+
+    assert result.exit_code == 2
+    assert "is not a url" in result.stderr
+
+
+def test_a_query_in_the_url_survives(client):
+    run("https://api.audible.de/1.0/library?num_results=5")
+
+    assert client.asked["url"] == "https://api.audible.de/1.0/library?num_results=5"
+
+
+def test_the_two_ways_of_giving_a_query_add_up(client):
+    run("https://api.audible.de/1.0/library?a=1", "-q", "b=2", "-q", "a=3")
+
+    assert client.asked["url"] == ("https://api.audible.de/1.0/library?a=1&b=2&a=3")
+
+
+def test_a_query_is_sent_exactly_as_it_was_written(client):
+    # A delivery url is signed over these bytes. Reading the query into
+    # pairs and writing it back would turn `%FF` into the replacement
+    # character, `%20` into `+`, and `flag` into `flag=`.
+    run("https://cds.audible.de/f.aax?sig=%FF&a=b%20c&flag")
+
+    assert client.asked["url"] == "https://cds.audible.de/f.aax?sig=%FF&a=b%20c&flag"
+
+
+def test_an_added_query_leaves_the_written_one_alone(client):
+    run("https://cds.audible.de/f.aax?sig=%FF", "-q", "z=1", "-q", "z=2")
+
+    assert client.asked["url"] == "https://cds.audible.de/f.aax?sig=%FF&z=1&z=2"
+
+
+def test_a_query_needs_a_name(client):
+    result = run("https://www.audible.de/x", "-q", "=nothing")
+
+    assert result.exit_code == 2
+    assert "has no name" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "method", ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"]
+)
+def test_every_method_reaches_the_client(client, method):
+    # Not a fixed list: a host that answers PATCH is not the client's
+    # business to argue with.
+    run("https://www.audible.de/x", "-m", method.lower())
+
+    assert client.asked["method"] == method
+
+
+def test_something_that_is_no_method_is_a_usage_error(client):
+    result = run("https://www.audible.de/x", "-m", "GET;DROP")
+
+    assert result.exit_code == 2
+    assert "not an http method" in result.stderr
+    assert client.asked is None
+
+
+def test_the_answer_is_streamed(client):
+    # A file from the delivery host runs to gigabytes, and reading it
+    # whole into memory before writing it out would not end well.
+    run("https://cds.audible.de/f.aax")
+
+    assert client.asked["stream"] is True
+
+
+def test_a_body_goes_out_as_it_was_written(client):
+    # Not json, and not turned into any: what is typed is what is sent.
+    run("https://www.audible.de/x", "-m", "POST", "-b", "a=1&b=2")
+
+    assert client.asked["content"] == b"a=1&b=2"
+
+
+def test_a_body_can_come_from_a_file(client, tmp_path):
+    path = tmp_path / "body.bin"
+    path.write_bytes(b"\x00\x01 raw")
+
+    run("https://www.audible.de/x", "-m", "POST", "--body-file", str(path))
+
+    assert client.asked["content"] == b"\x00\x01 raw"
+
+
+def test_a_body_can_come_through_a_pipe(client):
+    run("https://www.audible.de/x", "-m", "POST", "--body-file", "-", input="piped")
+
+    assert client.asked["content"] == b"piped"
+
+
+def test_the_two_ways_of_giving_a_body_exclude_each_other(client, tmp_path):
+    path = tmp_path / "body.bin"
+    path.write_bytes(b"x")
+
+    result = run("https://www.audible.de/x", "-b", "y", "--body-file", str(path))
+
+    assert result.exit_code == 2
+    assert "cannot both be given" in result.stderr
+    assert client.asked is None
+
+
+def test_a_header_reaches_the_request(client):
+    run("https://www.audible.de/x", "-H", "Accept: text/html")
+
+    assert client.asked["headers"] == [("Accept", "text/html")]
+
+
+def test_the_content_type_is_the_callers_to_set(client):
+    # `api` refuses it, because it writes the body itself. Here the body
+    # is whatever was given, so its type has to be too.
+    run(
+        "https://www.audible.de/x",
+        "-m",
+        "POST",
+        "-b",
+        "a=1",
+        "-H",
+        "Content-Type: application/x-www-form-urlencoded",
+    )
+
+    assert client.asked["headers"] == [
+        ("Content-Type", "application/x-www-form-urlencoded")
+    ]
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Authorization: Bearer x",
+        "x-adp-token: x",
+        "X-Amz-Access-Token: x",
+        "Host: foreign.host",
+    ],
+)
+def test_the_headers_that_carry_the_authentication_are_refused(client, header):
+    result = run("https://www.audible.de/x", "-H", header)
+
+    assert result.exit_code == 2
+    assert "cannot be given here" in result.stderr
+    assert client.asked is None
+
+
+def test_the_answer_reaches_stdout_as_it_arrived(monkeypatch):
+    # Bytes, not text: this command is what fetches a cover or a pdf.
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"\x89PNG\r\n\x1a\n",
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+
+    result = run("https://www.audible.de/x")
+
+    assert result.exit_code == 0
+    assert result.stdout_bytes == b"\x89PNG\r\n\x1a\n"
+
+
+def test_include_writes_the_head_before_the_body(monkeypatch):
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"body",
+            headers={"x-total-count": "7"},
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+
+    result = run("https://www.audible.de/x", "-i")
+
+    head, _, body = result.stdout_bytes.partition(b"\n\n")
+    assert head.startswith(b"HTTP/1.1 200 OK\n")
+    assert b"x-total-count: 7" in head
+    assert body == b"body"
+
+
+def test_the_answer_can_go_to_a_file(monkeypatch, tmp_path):
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"\x00\x01",
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "out.bin"
+
+    result = run("https://www.audible.de/x", "-o", str(path))
+
+    assert path.read_bytes() == b"\x00\x01"
+    assert result.stdout_bytes == b""
+
+
+def test_the_headers_can_be_written_to_a_file(monkeypatch, tmp_path):
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"body",
+            headers={"continuation-token": "abc"},
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "head.txt"
+
+    run("https://www.audible.de/x", "-D", str(path))
+
+    written = path.read_text(encoding="utf-8")
+    assert written.startswith("HTTP/1.1 200 OK\n")
+    assert "continuation-token: abc" in written
+
+
+def test_an_error_status_ends_the_command_after_the_answer(monkeypatch, tmp_path):
+    # The body of a refusal says why it was refused, so it is written
+    # before the status is reported.
+    answering(
+        monkeypatch,
+        httpx.Response(
+            403,
+            content=b'{"message": "no"}',
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "head.txt"
+
+    result = run("https://www.audible.de/x", "-D", str(path))
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "403" in str(result.exception)
+    assert result.stdout_bytes == b'{"message": "no"}'
+    assert path.read_text(encoding="utf-8").startswith("HTTP/1.1 403 Forbidden")
+
+
+def test_a_transport_error_is_reported_as_a_failure(monkeypatch):
+    class Failing(FakeClient):
+        def raw_request(self, method, url, **kwargs):
+            raise httpx.ConnectTimeout("too slow")
+
+    monkeypatch.setattr(Session, "get_client", lambda self, **kw: Failing())
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run("https://www.audible.de/x")
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert "too slow" in str(result.exception)
+
+
+def test_the_timeout_option_reaches_the_session(monkeypatch):
+    seen = {}
+
+    def get_client(self, **kw):
+        seen["timeout"] = self.params.get("timeout")
+        return FakeClient()
+
+    monkeypatch.setattr(Session, "get_client", get_client)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    assert run("https://www.audible.de/x", "--timeout", "60").exit_code == 0
+    assert seen["timeout"] == 60
+
+
+class NoAuth(httpx.Auth):
+    """Stands in for the Authenticator, which the real client insists on."""
+
+    def auth_flow(self, request):
+        yield request
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["https://www.audible.de/x"], "https://www.audible.de/x"),
+        (["https://www.audible.de/x?a=1"], "https://www.audible.de/x?a=1"),
+        (
+            ["https://www.audible.de/x?a=1", "-q", "a=2"],
+            "https://www.audible.de/x?a=1&a=2",
+        ),
+        # `flag` keeps its shape: a query written into the url is not
+        # read into pairs and written back.
+        (["https://www.audible.de/x?flag"], "https://www.audible.de/x?flag"),
+        (
+            ["https://www.audible.de/x?sig=%FF&a=b%20c"],
+            "https://www.audible.de/x?sig=%FF&a=b%20c",
+        ),
+    ],
+)
+def test_the_url_that_actually_goes_out(monkeypatch, args, expected):
+    # Through the real client, not a stand-in. httpx erases a url query
+    # when it is handed a `params` of its own, so the command takes the
+    # query apart and sends every pair along.
+    sent = {}
+
+    def handler(request):
+        sent["url"] = str(request.url)
+        return httpx.Response(200, content=b"")
+
+    def get_client(self, **kw):
+        return AsyncClient(
+            auth=NoAuth(),
+            country_code="de",
+            transport=httpx.MockTransport(handler),
+        )
+
+    monkeypatch.setattr(Session, "get_client", get_client)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run(*args)
+
+    assert result.exit_code == 0, result.exception
+    assert sent["url"] == expected
+
+
+def test_include_puts_the_head_wherever_the_body_goes(monkeypatch, tmp_path):
+    # With `-o` the file is the answer, so the head belongs in it. curl
+    # does the same, and `-D` stays the way to keep them apart.
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"body",
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "out.txt"
+
+    result = run("https://www.audible.de/x", "-i", "-o", str(path))
+
+    assert path.read_bytes().endswith(b"\n\nbody")
+    assert path.read_bytes().startswith(b"HTTP/1.1 200 OK\n")
+    assert result.stdout_bytes == b""
+
+
+def test_a_header_that_came_twice_is_written_twice(monkeypatch, tmp_path):
+    # Two `set-cookie` are not one `set-cookie` with a comma in it.
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=b"",
+            headers=[("set-cookie", "a=1"), ("set-cookie", "b=2")],
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "head.txt"
+
+    run("https://www.audible.de/x", "-D", str(path))
+
+    written = path.read_text(encoding="utf-8")
+    assert "set-cookie: a=1\n" in written
+    assert "set-cookie: b=2\n" in written
+
+
+def test_a_compressed_answer_arrives_readable(monkeypatch):
+    # httpx unpacks it on the way through. The headers still describe
+    # what came over the wire, which is what the server said.
+    answering(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=gzip.compress(b"plain text"),
+            headers={"content-encoding": "gzip"},
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+
+    result = run("https://www.audible.de/x", "-i")
+
+    head, _, body = result.stdout_bytes.partition(b"\n\n")
+    assert body == b"plain text"
+    assert b"content-encoding: gzip" in head
+
+
+def test_an_error_body_lands_in_the_output_file(monkeypatch, tmp_path):
+    answering(
+        monkeypatch,
+        httpx.Response(
+            500,
+            content=b"the server is unwell",
+            request=httpx.Request("GET", "https://www.audible.de/x"),
+        ),
+    )
+    path = tmp_path / "out.txt"
+
+    result = run("https://www.audible.de/x", "-o", str(path))
+
+    assert isinstance(result.exception, AudibleCliException)
+    assert path.read_bytes() == b"the server is unwell"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://192.0.2.1/x",
+        "https://[2001:db8::1]/x",
+        "https://api.audible.de.evil.test/x",
+        "https://api.audible.de.",
+        "https://xn--pi-audible-33a.de/x",
+    ],
+)
+def test_a_host_that_only_looks_right_is_refused(client, url):
+    assert run(url).exit_code == 2
+    assert client.asked is None
+
+
+def test_the_host_is_matched_whatever_the_shift_key_did(client):
+    assert run("https://API.Audible.DE/1.0/library").exit_code == 0
+
+
+def test_a_redirect_is_not_followed(monkeypatch):
+    # Through the real client: `follow_redirects=True` would send the
+    # credentials to wherever `location` points, and a stand-in client
+    # cannot show that it stays off.
+    asked = []
+
+    def handler(request):
+        asked.append(str(request.url))
+        if request.url.path == "/first":
+            return httpx.Response(
+                302, headers={"location": "https://cds.audible.de/second"}
+            )
+        return httpx.Response(200, content=b"followed")
+
+    def get_client(self, **kw):
+        return AsyncClient(
+            auth=NoAuth(),
+            country_code="de",
+            transport=httpx.MockTransport(handler),
+        )
+
+    monkeypatch.setattr(Session, "get_client", get_client)
+    monkeypatch.setattr(Session, "auth", property(lambda self: "AUTH"))
+
+    result = run("https://cde-ta-g7g.amazon.com/first", "-i")
+
+    assert asked == ["https://cde-ta-g7g.amazon.com/first"]
+    assert b"location: https://cds.audible.de/second" in result.stdout_bytes
+    assert isinstance(result.exception, AudibleCliException) is False


### PR DESCRIPTION
> **Based on #311.** The diff below is against `fix/api-takes-a-path`, not
> `master`. Both belong in the same release: #311 narrows `api` to the Audible
> API and to JSON, and this is where everything else goes, so that nothing is
> taken away without the replacement being there. Merge #311 first; GitHub
> retargets this one.

`audible api` speaks to the API and expects JSON back. The rest of what
audible-cli reaches had nowhere to go from the command line: the website a
companion file comes from, the delivery host that hands out the audio, Amazon's
CDE service for annotations, and every answer that is not JSON.

    audible request https://www.audible.de/companion-file/B07J2M2VC7 -o chapters.json
    audible request https://cde-ta-g7g.amazon.com/FionaCDEServiceEngine/sidecar \
        -q "type=AUDI" -q "key=B07J2M2VC7" -i

## Which hosts, and why there is a list at all

The request carries the credentials of the profile, so the list of allowed
hosts is the list of who may be handed them: `api`, `www`, `cds` and
`api.amazon` of any of the 11 marketplaces, plus `cde-ta-g7g.amazon.com`. That
is 45 hosts, derived in `constants.py` from the library's marketplace list, so
it grows with it. A url naming anything else is refused before any credentials
are loaded, as are plain http, a port of its own, and a name and password
written into the url.

## What passes through untouched

The url is sent as it was written, not parsed and rebuilt. A delivery url is
signed over those exact bytes, and reading its query into pairs turns `%FF`
into the replacement character, `%20` into `+` and `flag` into `flag=`.
`--query` appends to the raw query instead of merging into a parsed one.

The body goes out as it was given — bytes, not JSON — and the answer is
streamed, so a file of any size can go through `--output` without being held
whole in memory. The method is whatever the host understands, `PATCH` and
`OPTIONS` included.

`--include/-i` writes the status line and the response headers in front of the
body, wherever the body goes; `--dump-header/-D` writes them to a file of their
own. A header that came twice is written twice. A redirect is shown, not
followed. An error status ends the command after the answer has been written,
because the body of a refusal is what explains it.

## Shared with `api`

`QueryPair` and `HeaderPair` move to `_params.py`, so both commands split a
query and a header the same way and refuse the same headers. One name differs:
`api` writes the body itself and always as JSON, so it owns `content-type` as
well, while here the body is raw and its type is the caller's to declare.

## Tests

59, including two that go through the real `AsyncClient` behind a mock
transport, where a stand-in cannot help: the url that actually leaves, and that
a redirect is not followed — the second needs two hops to say anything.
